### PR TITLE
feat: add Go + C# hybrid backend  for faster seed search

### DIFF
--- a/StardewSeedSearcher/Core/HashHelper.cs
+++ b/StardewSeedSearcher/Core/HashHelper.cs
@@ -1,4 +1,5 @@
 using System.Data.HashFunction.xxHash;
+using System.Runtime.CompilerServices;
 using System.Text;
 
 namespace StardewSeedSearcher.Core
@@ -63,8 +64,60 @@ namespace StardewSeedSearcher.Core
             else
             {
                 // 新随机：使用 XXHash
-                return GetHashFromArray(a, b, c, d, e);
+                return GetHashFromFiveInts(a, b, c, d, e);
             }
         }
+
+        // xxHash32 over exactly five little-endian Int32 values, with seed 0.
+        // Equivalent to GetHashFromArray(a, b, c, d, e), without heap allocations.
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static int GetHashFromFiveInts(int a, int b, int c, int d, int e)
+        {
+            const uint prime1 = 2654435761U;
+            const uint prime2 = 2246822519U;
+            const uint prime3 = 3266489917U;
+            const uint prime4 = 668265263U;
+
+            static uint Round(uint accumulator, uint input)
+            {
+                accumulator += input * prime2;
+                accumulator = RotateLeft(accumulator, 13);
+                return accumulator * prime1;
+            }
+
+            unchecked
+            {
+                uint v1 = prime1 + prime2;
+                uint v2 = prime2;
+                uint v3 = 0;
+                uint v4 = 0U - prime1;
+
+                v1 = Round(v1, (uint)a);
+                v2 = Round(v2, (uint)b);
+                v3 = Round(v3, (uint)c);
+                v4 = Round(v4, (uint)d);
+
+                uint hash = RotateLeft(v1, 1)
+                          + RotateLeft(v2, 7)
+                          + RotateLeft(v3, 12)
+                          + RotateLeft(v4, 18);
+
+                hash += 20;
+                hash += (uint)e * prime3;
+                hash = RotateLeft(hash, 17) * prime4;
+
+                hash ^= hash >> 15;
+                hash *= prime2;
+                hash ^= hash >> 13;
+                hash *= prime3;
+                hash ^= hash >> 16;
+
+                return (int)hash;
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static uint RotateLeft(uint value, int count) =>
+            (value << count) | (value >> (32 - count));
     }
 }

--- a/StardewSeedSearcher/Features/DesertFestivalPredictor.cs
+++ b/StardewSeedSearcher/Features/DesertFestivalPredictor.cs
@@ -39,6 +39,9 @@ namespace StardewSeedSearcher.Features
             "Harvey", "Elliott", "Demetrius", "Maru", "Robin", "Sebastian", "Linus",
             "Wizard", "Jas", "Marnie", "Shane", "Leah", "Dwarf", "Sandy", "Willy"
         };
+
+        // Eligible vendor order is fixed; cache it for the allocation-free check path.
+        private static readonly string[][] VENDOR_POOLS = BuildVendorPools();
         
         /// <summary>
         /// 检查种子是否满足筛选条件（ISearchFeature接口实现）
@@ -48,7 +51,8 @@ namespace StardewSeedSearcher.Features
             if (!IsEnabled)
                 return true;
 
-            return MeetsVendorRequirement(gameID, useLegacyRandom, RequireJas, RequireLeah);
+            return MeetsVendorRequirementWithoutAllocations(
+                gameID, useLegacyRandom, RequireJas, RequireLeah);
         }
 
         /// <summary>
@@ -174,7 +178,63 @@ namespace StardewSeedSearcher.Features
         /// </summary>
         /// <param name="d">相对日期（0=春15, 1=春16, 2=春17）</param>
         /// <returns>候选村民列表（保持固定顺序）</returns>
-        private List<string> BuildVendorPool(int d)
+        private static bool MeetsVendorRequirementWithoutAllocations(
+            int gameID, bool useLegacyRandom, bool requireJas, bool requireLeah)
+        {
+            if (!requireJas && !requireLeah)
+                return true;
+
+            bool hasJas = false;
+            bool hasLeah = false;
+            Span<int> indexBuffer = stackalloc int[CHARACTERS_IN_ORDER.Count];
+
+            // Stack-backed indices reproduce List.RemoveAt without creating
+            // dictionaries and lists for every checked seed.
+            for (int d = 0; d < 3; d++)
+            {
+                string[] vendorPool = VENDOR_POOLS[d];
+                Span<int> activeIndices = indexBuffer[..vendorPool.Length];
+                for (int i = 0; i < activeIndices.Length; i++)
+                    activeIndices[i] = i;
+
+                int activeCount = activeIndices.Length;
+                int seed = HashHelper.GetRandomSeed(15 + d, gameID / 2, 0, 0, 0, useLegacyRandom);
+                Random rng = new Random(seed);
+
+                for (int i = 0; i < d * 2; i++)
+                    RemoveAt(activeIndices, ref activeCount, rng.Next(activeCount));
+
+                for (int i = 0; i < 2; i++)
+                {
+                    int selectedIndex = rng.Next(activeCount);
+                    string selectedVendor = vendorPool[activeIndices[selectedIndex]];
+                    hasJas |= selectedVendor == "Jas";
+                    hasLeah |= selectedVendor == "Leah";
+                    RemoveAt(activeIndices, ref activeCount, selectedIndex);
+                }
+
+                if ((!requireJas || hasJas) && (!requireLeah || hasLeah))
+                    return true;
+            }
+
+            return false;
+        }
+
+        private static void RemoveAt(Span<int> indices, ref int count, int index)
+        {
+            indices.Slice(index + 1, count - index - 1).CopyTo(indices.Slice(index));
+            count--;
+        }
+
+        private static string[][] BuildVendorPools()
+        {
+            var pools = new string[3][];
+            for (int d = 0; d < pools.Length; d++)
+                pools[d] = BuildVendorPool(d).ToArray();
+            return pools;
+        }
+
+        private static List<string> BuildVendorPool(int d)
         {
             var pool = new List<string>();
             var exclusion = SCHEDULE_EXCLUSION[d];

--- a/StardewSeedSearcher/Features/FairyPredictor.cs
+++ b/StardewSeedSearcher/Features/FairyPredictor.cs
@@ -26,13 +26,31 @@ namespace StardewSeedSearcher.Features
     {
         public bool IsEnabled { get; set; }
         public List<FairyCondition> Conditions { get; set; } = new();
+        private FairyCondition[] _sortedConditions = [];
 
         public string Name => "仙子预测";
+
+        public void Prepare()
+        {
+            _sortedConditions = Conditions
+                .OrderBy(EstimateCostPerCondition)
+                .ToArray();
+        }
+
+        private void EnsurePrepared()
+        {
+            if (_sortedConditions.Length != Conditions.Count)
+            {
+                Prepare();
+            }
+        }
 
         public bool Check(int seed, bool useLegacyRandom)
         {
             if (Conditions.Count == 0)
                 return true;
+
+            EnsurePrepared();
 
             // 实例化天气预测器并预计算绿雨日，用于次日天气判定
             var wp = new WeatherPredictor();
@@ -41,10 +59,8 @@ namespace StardewSeedSearcher.Features
             // 动态排序
             // 仙子概率极低（1%），所以范围越窄的条件越容易在极短时间内证明“失败”
             // 优先检查预计耗时最短且最容易失败的范围
-            var sortedConditions = Conditions.OrderBy(EstimateCostPerCondition).ToList();
-
             // 所有条件都必须满足（AND）
-            foreach (var condition in sortedConditions)
+            foreach (var condition in _sortedConditions)
             {
                 int foundCount = 0;
                 
@@ -128,7 +144,8 @@ namespace StardewSeedSearcher.Features
             int callsPerDay = useLegacyRandom ? 1 : 11;
 
             // 找到范围最窄的条件
-            var bestCondition = Conditions.OrderBy(EstimateCostPerCondition).First();
+            EnsurePrepared();
+            var bestCondition = _sortedConditions[0];
             
             // 期望开销 = 预期检查天数 * 单日成本
             return EstimateCostPerCondition(bestCondition) * callsPerDay;

--- a/StardewSeedSearcher/Features/FairyPredictor.cs
+++ b/StardewSeedSearcher/Features/FairyPredictor.cs
@@ -27,6 +27,7 @@ namespace StardewSeedSearcher.Features
         public bool IsEnabled { get; set; }
         public List<FairyCondition> Conditions { get; set; } = new();
         private FairyCondition[] _sortedConditions = [];
+        private readonly WeatherPredictor _weatherPredictor = new();
 
         public string Name => "仙子预测";
 
@@ -53,8 +54,7 @@ namespace StardewSeedSearcher.Features
             EnsurePrepared();
 
             // 实例化天气预测器并预计算绿雨日，用于次日天气判定
-            var wp = new WeatherPredictor();
-            int greenRainDay = wp.GetGreenRainDay(seed, useLegacyRandom);
+            int greenRainDay = _weatherPredictor.GetGreenRainDay(seed, useLegacyRandom);
 
             // 动态排序
             // 仙子概率极低（1%），所以范围越窄的条件越容易在极短时间内证明“失败”
@@ -81,7 +81,7 @@ namespace StardewSeedSearcher.Features
                         int nextDayAbs = day + 1;
                         var nextDate = TimeHelper.AbsoluteDaytoDate(nextDayAbs);
 
-                        bool isNextDayRainy = wp.IsRainyDay(
+                        bool isNextDayRainy = _weatherPredictor.IsRainyDay(
                             nextDate.season, 
                             nextDate.day, 
                             nextDayAbs, 

--- a/StardewSeedSearcher/Features/ISearchFeature.cs
+++ b/StardewSeedSearcher/Features/ISearchFeature.cs
@@ -12,6 +12,9 @@ namespace StardewSeedSearcher.Features
         /// <summary>是否启用此功能</summary>
         bool IsEnabled { get; set; }
 
+        /// <summary>Precomputes immutable data used by the search hot path.</summary>
+        void Prepare() { }
+
         /// <summary>
         /// 检查种子是否符合此功能的筛选条件
         /// </summary>

--- a/StardewSeedSearcher/Features/MonsterLevelPredictor.cs
+++ b/StardewSeedSearcher/Features/MonsterLevelPredictor.cs
@@ -4,6 +4,8 @@ namespace StardewSeedSearcher.Features
 {
     public class MonsterLevelPredictor : ISearchFeature
     {
+        private MonsterLevelCondition[] _sortedConditions = [];
+
         public List<MonsterLevelCondition> Conditions { get; set; } = new();
         
         public string Name => "怪物层";
@@ -28,15 +30,30 @@ namespace StardewSeedSearcher.Features
         /// <summary>
         /// 检查种子是否匹配所有条件（AND关系）
         /// </summary>
+        public void Prepare()
+        {
+            _sortedConditions = Conditions
+                .OrderBy(EstimateCostPerCondition)
+                .ToArray();
+        }
+
+        private void EnsurePrepared()
+        {
+            if (_sortedConditions.Length != Conditions.Count)
+            {
+                Prepare();
+            }
+        }
+
         public bool Check(int gameID, bool useLegacyRandom)
         {
             if (!IsEnabled) return true;
 
-            // 动态排序
-            var sortedConditions = Conditions.OrderBy(EstimateCostPerCondition).ToList();
+            EnsurePrepared();
 
+            // 动态排序
             // 遍历每个条件
-            foreach (var condition in sortedConditions)
+            foreach (var condition in _sortedConditions)
             {
                 // 检查指定日期和层数范围内是否有感染层
                 for (int day = condition.AbsoluteStartDay; day <= condition.AbsoluteEndDay; day++)
@@ -104,7 +121,8 @@ namespace StardewSeedSearcher.Features
             if (!IsEnabled || Conditions.Count == 0) return 0;
             
             // 找到范围最小（检查次数最少）的条件
-            var bestCondition = Conditions.OrderBy(EstimateCostPerCondition).First();
+            EnsurePrepared();
+            var bestCondition = _sortedConditions[0];
             
             // 返回该条件的 RNG 总调用次数
             return EstimateCostPerCondition(bestCondition);

--- a/StardewSeedSearcher/Features/TravelingCartPredictor.cs
+++ b/StardewSeedSearcher/Features/TravelingCartPredictor.cs
@@ -59,23 +59,39 @@ namespace StardewSeedSearcher.Features
     {
         public bool IsEnabled { get; set; }
         public List<CartCondition> Conditions { get; set; } = new();
+        private CartCondition[] _sortedConditions = [];
 
         public string Name => "猪车预测";
+
+        public void Prepare()
+        {
+            _sortedConditions = Conditions
+                .OrderBy(EstimateCostPerCondition)
+                .ToArray();
+        }
+
+        private void EnsurePrepared()
+        {
+            if (_sortedConditions.Length != Conditions.Count)
+            {
+                Prepare();
+            }
+        }
 
         public bool Check(int seed, bool useLegacyRandom)
         {
             if (Conditions.Count == 0)
                 return true;
 
+            EnsurePrepared();
+
             // --- 动态排序优化 ---
             // 按照分数从小到大排序，优先执行最稀有、范围最小的条件
-            var sortedConditions = Conditions.OrderBy(EstimateCostPerCondition).ToList();
-
             int guaranteeSeed = HashHelper.GetRandomSeed(12 * seed, 0, 0, 0, 0, useLegacyRandom);
             int originalGuarantee = new Random(guaranteeSeed).Next(2, 31);
 
             // 所有条件都必须满足（AND）
-            foreach (var condition in sortedConditions)
+            foreach (var condition in _sortedConditions)
             {
                 // 找到 minOccurrences 个匹配即可提前退出
                 int matches = 0;
@@ -132,7 +148,8 @@ namespace StardewSeedSearcher.Features
             if (Conditions.Count == 0) return 0;
             
             // 取排序后第一个条件的期望开销
-            var bestCondition = Conditions.OrderBy(EstimateCostPerCondition).First();
+            EnsurePrepared();
+            var bestCondition = _sortedConditions[0];
                 
             return (int)EstimateCostPerCondition(bestCondition);
         }

--- a/StardewSeedSearcher/Features/WeatherPredictor.cs
+++ b/StardewSeedSearcher/Features/WeatherPredictor.cs
@@ -27,6 +27,22 @@ namespace StardewSeedSearcher.Features
         public bool IsEnabled { get; set; } = true;
         public int locationHash = HashHelper.GetHashFromString("location_weather");
 
+        private WeatherCondition[] _sortedConditions = [];
+
+        public void Prepare()
+        {
+            _sortedConditions = Conditions
+                .OrderBy(EstimateCostPerCondition)
+                .ToArray();
+        }
+
+        private void EnsurePrepared()
+        {
+            if (_sortedConditions.Length != Conditions.Count)
+            {
+                Prepare();
+            }
+        }
 
         /// <summary>
         /// 检查种子是否符合筛选条件
@@ -36,14 +52,14 @@ namespace StardewSeedSearcher.Features
             if (Conditions.Count == 0)
                 return true;
 
+            EnsurePrepared();
+
             // 只计算一次绿雨
             int greenRainDay = GetGreenRainDay(gameID, useLegacyRandom);
 
             // 动态排序，优先检查范围窄、要求高的条件
-            var sortedConditions = Conditions.OrderBy(EstimateCostPerCondition).ToList();
-            
             // 逐条件检查，失败立即返回
-            foreach (var condition in sortedConditions)
+            foreach (var condition in _sortedConditions)
             {
                 int rainCount = 0;
                 int totalInRange = condition.AbsoluteEndDay - condition.AbsoluteStartDay + 1;
@@ -130,11 +146,13 @@ namespace StardewSeedSearcher.Features
         /// <summary>
         /// 计算绿雨日期
         /// </summary>
+        
+        public static readonly int[] greenRainDays = { 5, 6, 7, 14, 15, 16, 18, 23 };
         public int GetGreenRainDay(int gameID, bool useLegacyRandom)
         {
             int greenRainSeed = HashHelper.GetRandomSeed(777, gameID, 0, 0, 0, useLegacyRandom);
             Random greenRainRng = new Random(greenRainSeed);
-            int[] greenRainDays = { 5, 6, 7, 14, 15, 16, 18, 23 };
+            // int[] greenRainDays = { 5, 6, 7, 14, 15, 16, 18, 23 };
             int greenRainDay = greenRainDays[greenRainRng.Next(greenRainDays.Length)];
             return greenRainDay;
         }
@@ -188,7 +206,8 @@ namespace StardewSeedSearcher.Features
             if (Conditions.Count == 0) return 0;
             
             // 找到最容易失败（最便宜）的那个条件
-            var bestCondition = Conditions.OrderBy(EstimateCostPerCondition).First();
+            EnsurePrepared();
+            var bestCondition = _sortedConditions[0];
             
             // 基础开销(绿雨56次) + 第一个条件的预期天数
             return 56 + EstimateCostPerCondition(bestCondition);

--- a/StardewSeedSearcher/Features/WeatherPredictor.cs
+++ b/StardewSeedSearcher/Features/WeatherPredictor.cs
@@ -26,6 +26,7 @@ namespace StardewSeedSearcher.Features
         public string Name => "天气预测";
         public bool IsEnabled { get; set; } = true;
         public int locationHash = HashHelper.GetHashFromString("location_weather");
+        private static readonly int SummerRainChanceHash = HashHelper.GetHashFromString("summer_rain_chance");
 
         private WeatherCondition[] _sortedConditions = [];
 
@@ -176,7 +177,7 @@ namespace StardewSeedSearcher.Features
             int rainSeed = HashHelper.GetRandomSeed(
                 absoluteDay - 1, 
                 gameID / 2, 
-                HashHelper.GetHashFromString("summer_rain_chance"), 0, 0, useLegacyRandom);
+                SummerRainChanceHash, 0, 0, useLegacyRandom);
             Random rainRng = new Random(rainSeed);
             double rainChance = 0.12 + 0.003 * (dayOfMonth - 1);
             return rainRng.NextDouble() < rainChance;

--- a/StardewSeedSearcher/ProgramWeb.cs
+++ b/StardewSeedSearcher/ProgramWeb.cs
@@ -24,7 +24,7 @@ namespace StardewSeedSearcher
 
 
         // 获得种子简介信息
-        private static object CollectAllDetails(int seed, bool useLegacy, List<ISearchFeature> features)
+        internal static object CollectAllDetails(int seed, bool useLegacy, List<ISearchFeature> features)
         {
             WeatherDetailResult weatherDetail = null;
             List<object> fairyDays = null;
@@ -84,6 +84,12 @@ namespace StardewSeedSearcher
 
         public static void Main(string[] args)
         {
+            if (args.Any(arg => arg.Equals("--worker", StringComparison.OrdinalIgnoreCase)))
+            {
+                SearchWorker.RunAsync().GetAwaiter().GetResult();
+                return;
+            }
+
             // 拉取猪车物品列表
             TravelingCartData.Initialize();
             
@@ -462,7 +468,7 @@ namespace StardewSeedSearcher
         /// </summary>
         /// <param name="request"></param>
         /// <returns></returns>
-        private static List<ISearchFeature> InitializeFeatures(SearchRequest request)
+        internal static List<ISearchFeature> InitializeFeatures(SearchRequest request)
         {
             var features = new List<ISearchFeature>();
             // 配置天气功能
@@ -597,7 +603,7 @@ namespace StardewSeedSearcher
         /// </summary>
         /// <param name="request"></param>
         /// <returns></returns>
-        private static object GetEnabledFeatures(SearchRequest request) => new
+        internal static object GetEnabledFeatures(SearchRequest request) => new
         {
             weather = request.WeatherConditions?.Count > 0, // 如果为null则false，否则判断数量是否大于0
             weatherSeasons = request.WeatherConditions?.Select(c => c.Season).Distinct().ToList() ?? [],

--- a/StardewSeedSearcher/ProgramWeb.cs
+++ b/StardewSeedSearcher/ProgramWeb.cs
@@ -595,6 +595,11 @@ namespace StardewSeedSearcher
                 features.Add(cartPredictor);
             }
 
+            foreach (var feature in features)
+            {
+                feature.Prepare();
+            }
+
             return features;
         }
 

--- a/StardewSeedSearcher/SearchWorker.cs
+++ b/StardewSeedSearcher/SearchWorker.cs
@@ -1,0 +1,207 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using StardewSeedSearcher.Data;
+using StardewSeedSearcher.Features;
+
+namespace StardewSeedSearcher
+{
+    internal static class SearchWorker
+    {
+        private static readonly JsonSerializerOptions JsonOptions = new()
+        {
+            PropertyNameCaseInsensitive = true,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+        };
+
+        public static async Task RunAsync()
+        {
+            Console.InputEncoding = Encoding.UTF8;
+            Console.OutputEncoding = Encoding.UTF8;
+            TravelingCartData.Initialize();
+
+            string? line;
+            while ((line = await Console.In.ReadLineAsync()) != null)
+            {
+                if (string.IsNullOrWhiteSpace(line))
+                    continue;
+
+                WorkerResponse response;
+                try
+                {
+                    var request = JsonSerializer.Deserialize<WorkerRequest>(line, JsonOptions)
+                                  ?? throw new InvalidOperationException("Empty worker request.");
+
+                    response = request.Type switch
+                    {
+                        "cartItems" => BuildCartItemsResponse(request.Id),
+                        "search" => BuildSearchResponse(request),
+                        _ => WorkerResponse.Failed(request.Id, $"Unknown worker request type: {request.Type}")
+                    };
+                }
+                catch (Exception ex)
+                {
+                    response = WorkerResponse.Failed(null, ex.Message);
+                }
+
+                await Console.Out.WriteLineAsync(JsonSerializer.Serialize(response, JsonOptions));
+                await Console.Out.FlushAsync();
+            }
+        }
+
+        private static WorkerResponse BuildCartItemsResponse(string? id)
+        {
+            var items = TravelingCartData.OptimizedItems
+                .Where(item => item.IsEligible)
+                .Select(item => item.Name)
+                .Concat(TravelingCartData.SkillBooks)
+                .Distinct()
+                .OrderBy(name => name)
+                .ToList();
+
+            return new WorkerResponse
+            {
+                Id = id,
+                Type = "cartItems",
+                Items = items
+            };
+        }
+
+        private static WorkerResponse BuildSearchResponse(WorkerRequest workerRequest)
+        {
+            var request = workerRequest.Request
+                          ?? throw new InvalidOperationException("Search request is required.");
+
+            var features = ProgramWeb.InitializeFeatures(request);
+            var sortedFeatures = features
+                .Where(f => f.IsEnabled)
+                .OrderBy(f => f.EstimateCost(request.UseLegacyRandom))
+                .ToList();
+
+            var passCounts = sortedFeatures.ToDictionary(f => f.Name, _ => 0);
+            var matches = new List<WorkerSeedMatch>();
+            var enabledFeatures = ProgramWeb.GetEnabledFeatures(request);
+            var maxResults = workerRequest.MaxResults <= 0 ? int.MaxValue : workerRequest.MaxResults;
+            var checkedCount = 0;
+
+            for (long longSeed = workerRequest.StartSeed; longSeed <= workerRequest.EndSeed; longSeed++)
+            {
+                var seed = (int)longSeed;
+                var allMatch = true;
+
+                foreach (var feature in sortedFeatures)
+                {
+                    if (!feature.Check(seed, request.UseLegacyRandom))
+                    {
+                        allMatch = false;
+                        break;
+                    }
+
+                    passCounts[feature.Name]++;
+                }
+
+                checkedCount++;
+
+                if (allMatch)
+                {
+                    matches.Add(new WorkerSeedMatch
+                    {
+                        Seed = seed,
+                        Details = ProgramWeb.CollectAllDetails(seed, request.UseLegacyRandom, features),
+                        EnabledFeatures = enabledFeatures
+                    });
+
+                    if (matches.Count >= maxResults)
+                        break;
+                }
+
+                if (longSeed == int.MaxValue)
+                    break;
+            }
+
+            return new WorkerResponse
+            {
+                Id = workerRequest.Id,
+                Type = "search",
+                CheckedCount = checkedCount,
+                Matches = matches,
+                FeatureStats = sortedFeatures
+                    .Select(feature => new WorkerFeatureStat { Name = feature.Name, PassCount = passCounts[feature.Name] })
+                    .ToList()
+            };
+        }
+    }
+
+    internal sealed class WorkerRequest
+    {
+        [JsonPropertyName("id")]
+        public string? Id { get; set; }
+
+        [JsonPropertyName("type")]
+        public string Type { get; set; } = "search";
+
+        [JsonPropertyName("request")]
+        public SearchRequest? Request { get; set; }
+
+        [JsonPropertyName("startSeed")]
+        public int StartSeed { get; set; }
+
+        [JsonPropertyName("endSeed")]
+        public long EndSeed { get; set; }
+
+        [JsonPropertyName("maxResults")]
+        public int MaxResults { get; set; }
+    }
+
+    internal sealed class WorkerResponse
+    {
+        [JsonPropertyName("id")]
+        public string? Id { get; set; }
+
+        [JsonPropertyName("type")]
+        public string Type { get; set; } = "search";
+
+        [JsonPropertyName("checkedCount")]
+        public int CheckedCount { get; set; }
+
+        [JsonPropertyName("matches")]
+        public List<WorkerSeedMatch>? Matches { get; set; }
+
+        [JsonPropertyName("featureStats")]
+        public List<WorkerFeatureStat>? FeatureStats { get; set; }
+
+        [JsonPropertyName("items")]
+        public List<string>? Items { get; set; }
+
+        [JsonPropertyName("error")]
+        public string? Error { get; set; }
+
+        public static WorkerResponse Failed(string? id, string error) => new()
+        {
+            Id = id,
+            Type = "error",
+            Error = error
+        };
+    }
+
+    internal sealed class WorkerSeedMatch
+    {
+        [JsonPropertyName("seed")]
+        public int Seed { get; set; }
+
+        [JsonPropertyName("details")]
+        public object? Details { get; set; }
+
+        [JsonPropertyName("enabledFeatures")]
+        public object? EnabledFeatures { get; set; }
+    }
+
+    internal sealed class WorkerFeatureStat
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = string.Empty;
+
+        [JsonPropertyName("passCount")]
+        public int PassCount { get; set; }
+    }
+}

--- a/StardewSeedSearcher/development.md
+++ b/StardewSeedSearcher/development.md
@@ -1,0 +1,424 @@
+# StardewSeedSearcher 开发文档
+
+> [!Note] 本文档描述了运行go后端的方法，跟着此文档可以搭建起:
+> 原 C# 后端 \
+> Go + C# 混合后端
+
+
+## 1. 项目结构
+
+仓库根目录大致如下：
+
+```text
+StardewSeedSearcher/
+├─ index.html
+├─ script.js
+├─ style.css
+├─ avatar.png / background.png / logo.png
+└─ StardewSeedSearcher/
+   ├─ StardewSeedSearcher.csproj
+   ├─ ProgramWeb.cs              # 原 C# Web 后端入口
+   ├─ SearchWorker.cs            # C# worker，供 Go 混合后端调用
+   ├─ main.go                    # Go 混合后端入口
+   ├─ go.mod
+   ├─ Core/
+   ├─ Data/
+   ├─ Features/
+   └─ internal/
+      ├─ server/                 # Go HTTP / WebSocket 服务
+      ├─ worker/                 # Go 管理 C# worker 进程
+      └─ ws/                     # Go 标准库 WebSocket 薄实现
+```
+
+> [!important]
+> Windows 对路径大小写不敏感，`Internal` 和 `internal` 指向同一个目录；Go 代码里按惯例使用小写 `internal`
+
+## 2. 编程语言
+
+开发混合后端需要两个工具链：
+
+1. Go
+2. .NET SDK
+
+> [!note]
+> 一般用户不需要安装 Go；只有开发者需要发布时可以把 Go 编译成 exe
+
+### 2.1 安装 Go
+
+1. 打开 Go 官方下载页：`https://go.dev/dl/`
+2. 下载 Windows x64 的 `.msi` 安装包
+3. 一路默认安装即可
+4. 重新打开 PowerShell，执行：
+
+```powershell
+go version
+```
+
+能看到类似输出就说明安装好了：
+
+```text
+go version go1.23.x windows/amd64
+```
+
+本项目 `go.mod` 当前要求：
+
+```text
+go 1.23
+```
+
+> [!important]
+> 如果你的 Go 版本低于 1.23，建议升级
+
+### 2.2 安装 .NET SDK
+
+1. 打开 .NET 下载页：`https://dotnet.microsoft.com/download`
+2. 安装 `.NET 9 SDK`
+3. 重新打开 PowerShell，执行：
+
+```powershell
+dotnet --version
+```
+
+能看到 `9.x.x` 版本即可
+
+项目 C# 目标框架是：
+
+```xml
+<TargetFramework>net9.0</TargetFramework>
+```
+
+所以只装 .NET Runtime 不够，开发时需要 SDK
+
+## 3. 环境检查
+
+在仓库根目录执行：
+
+```powershell
+cd E:\Haruko386-UnOffical\CYY\StardewSeedSearcher
+go version
+dotnet --version
+```
+
+然后检查 C# 是否能编译：
+
+```powershell
+dotnet build .\StardewSeedSearcher\StardewSeedSearcher.csproj
+```
+
+检查 Go 是否能编译：
+
+```powershell
+cd .\StardewSeedSearcher
+go build ./...
+```
+
+> [!tip]
+> 目前 Go 代码没有第三方依赖，只使用标准库，所以一般不需要额外 `go get`
+
+## 4. 运行原 C# 后端
+
+原 C# 后端是纯 C# Web 服务，默认端口是 `5000`
+
+从仓库根目录执行：
+
+```powershell
+dotnet build .\StardewSeedSearcher\StardewSeedSearcher.csproj
+cd .\StardewSeedSearcher\bin\Debug\net9.0
+.\StardewSeedSearcher.exe
+```
+
+启动后：
+
+```text
+HTTP:      http://localhost:5000
+WebSocket: ws://localhost:5000/ws
+```
+
+前端右上角选择：
+
+```text
+C#: http://localhost:5000
+```
+
+## 5. 运行 Go + C# 混合后端
+
+混合后端的分工：
+
+- Go：HTTP API、WebSocket、goroutine 并发调度、任务分片、结果聚合
+- C#：具体种子推理和计算
+- 两者之间：Go 启动多个 C# worker 进程，用 JSON Lines 通过 stdin/stdout 通信
+
+### 5.1 默认运行
+
+> [!important]
+> 建议混合后端使用 `5050`，避免和原 C# 后端的 `5000` 冲突
+
+从仓库根目录执行：
+
+```powershell
+cd .\StardewSeedSearcher
+$env:SEED_GO_ADDR="localhost:5050"
+go run .
+```
+
+启动后前端右上角选择：
+
+```text
+Go＆C#: http://localhost:5050
+```
+
+### 5.2 Go 后端会自动启动 C# worker
+
+开发环境下，Go 会尝试寻找并启动 C# 编译结果：
+
+```text
+bin\Release\net9.0\StardewSeedSearcher.dll
+bin\Debug\net9.0\StardewSeedSearcher.dll
+```
+
+如果找不到，会尝试执行：
+
+```powershell
+dotnet build
+```
+
+所以第一次运行混合后端前，推荐先手动执行一次：
+
+```powershell
+dotnet build .\StardewSeedSearcher.csproj
+```
+
+如果你当前目录在仓库根目录，则执行：
+
+```powershell
+dotnet build .\StardewSeedSearcher\StardewSeedSearcher.csproj
+```
+
+### 5.3 混合后端环境变量
+
+可以通过环境变量调整 Go 后端：
+
+```powershell
+$env:SEED_GO_ADDR="localhost:5050"
+$env:SEED_GO_WORKERS="7"
+$env:SEED_GO_CHUNK="10000"
+go run .
+```
+
+含义：
+
+```text
+SEED_GO_ADDR     Go 混合后端监听地址，默认 localhost:5000
+SEED_GO_WORKERS  C# worker 进程数量，默认 CPU 核心数 - 1
+SEED_GO_CHUNK    每个 C# worker 一次处理的种子区间大小，默认 10000
+```
+
+一般只需要设置 `SEED_GO_ADDR`
+
+## 6. 前端页面
+
+直接双击仓库根目录的：
+
+```text
+index.html
+```
+
+右上角连接状态旁边有一个小按钮，展开后有两行：
+
+```text
+C#:     http://localhost:5000
+Go＆C#: http://localhost:5050
+```
+
+点击切换到对应后端，并重新连接 WebSocket
+
+也可以直接用 URL 参数指定后端：
+
+```text
+index.html?backend=http://localhost:5050
+```
+
+## 7. 开发流程
+
+### 7.1 只改前端
+
+修改：
+
+```text
+index.html
+script.js
+style.css
+```
+
+然后刷新浏览器即可
+
+如果浏览器缓存比较顽固，可以按：
+
+```text
+Ctrl + F5
+```
+
+### 7.2 只改 C# 算法
+
+修改：
+
+```text
+Core/
+Features/
+Data/
+ProgramWeb.cs
+SearchWorker.cs
+```
+
+然后重新构建：
+
+```powershell
+dotnet build .\StardewSeedSearcher\StardewSeedSearcher.csproj
+```
+
+> [!warning]
+> 如果正在运行原 C# 后端或 Go 混合后端，可能会锁住 `bin\Debug\net9.0\StardewSeedSearcher.dll`先关闭正在运行的黑色命令行窗口，再重新 build
+
+### 7.3 只改 Go 调度层
+
+修改：
+
+```text
+StardewSeedSearcher/main.go
+StardewSeedSearcher/internal/server/
+StardewSeedSearcher/internal/worker/
+StardewSeedSearcher/internal/ws/
+```
+
+检查：
+
+```powershell
+cd .\StardewSeedSearcher
+go build ./...
+```
+
+运行：
+
+```powershell
+$env:SEED_GO_ADDR="localhost:5050"
+go run .
+```
+
+## 8. 常见问题
+
+### 8.1 `go` 不是内部或外部命令
+
+说明 Go 没装好，或者 PATH 没刷新
+
+处理：
+
+1. 确认已经安装 Go
+2. 关闭当前 PowerShell
+3. 重新打开 PowerShell
+4. 再执行：
+
+```powershell
+go version
+```
+
+### 8.2 `dotnet` 不是内部或外部命令
+
+说明 .NET SDK 没装好，或者 PATH 没刷新
+
+处理方式同上，安装 `.NET 9 SDK` 后重新打开 PowerShell
+
+### 8.3 端口被占用
+
+如果看到类似：
+
+```text
+Only one usage of each socket address is normally permitted
+```
+
+说明端口已经被另一个后端占用
+
+处理：
+
+- 原 C# 后端默认占用 `5000`
+- Go 混合后端建议占用 `5050`
+
+运行混合后端时使用：
+
+```powershell
+$env:SEED_GO_ADDR="localhost:5050"
+go run .
+```
+
+### 8.4 `StardewSeedSearcher.dll` 被占用，无法 build
+
+这是因为旧后端还在运行
+
+处理：
+
+1. 关闭正在运行的原 C# 后端窗口
+2. 关闭正在运行的 Go 混合后端窗口
+3. 再执行：
+
+```powershell
+dotnet build .\StardewSeedSearcher\StardewSeedSearcher.csproj
+```
+
+如果只是想验证 C# 编译，也可以临时构建 Release：
+
+```powershell
+dotnet build .\StardewSeedSearcher\StardewSeedSearcher.csproj -c Release
+```
+
+### 8.5 前端一直显示未连接
+
+检查顺序：
+
+1. 后端是否真的启动了
+2. 前端右上角选择的地址是否正确
+3. C# 后端通常是 `http://localhost:5000`
+4. Go 混合后端通常是 `http://localhost:5050`
+5. 浏览器按 `F12`，看 Console 有没有报错
+
+可以用 PowerShell 测试后端健康检查：
+
+```powershell
+Invoke-RestMethod http://localhost:5000/api/health
+Invoke-RestMethod http://localhost:5050/api/health
+```
+
+哪个后端没启动，哪个命令就会失败
+
+## 9. 发布免安装版本
+
+开发时需要 Go 和 .NET SDK，但用户不应当安装这些编程语言
+
+```text
+脆音音搜种器/
+├─ Data/
+├─ index.html
+├─ script.js
+├─ style.css
+├─ avatar.png
+├─ background.png
+├─ logo.png
+├─ StardewSeedSearcher.exe        # C# self-contained worker / 原后端
+├─ StardewSeedSearcherHybrid.exe  # Go 编译出的混合后端
+└─ start（点这个启动）.bat
+```
+
+**Go 发布：**
+
+```powershell
+cd .\StardewSeedSearcher
+go build -o StardewSeedSearcherHybrid.exe .
+```
+
+**C# 发布：**
+
+```powershell
+dotnet publish .\StardewSeedSearcher.csproj -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true
+```
+
+> [!tip]
+> 发布脚本需要根据最终目录再单独整理开发阶段仅需要确保 `dotnet build`、`go build ./...` 和 `go run .` 的运行正常
+

--- a/StardewSeedSearcher/go.mod
+++ b/StardewSeedSearcher/go.mod
@@ -1,0 +1,3 @@
+module stardewseedsearcher
+
+go 1.23

--- a/StardewSeedSearcher/internal/server/server.go
+++ b/StardewSeedSearcher/internal/server/server.go
@@ -31,6 +31,7 @@ type searchRun struct {
 	cancelled atomic.Bool
 }
 
+// New creates a server with the given C# worker pool.
 func New(pool *worker.Pool) *Server {
 	return &Server{
 		pool: pool,
@@ -38,6 +39,7 @@ func New(pool *worker.Pool) *Server {
 	}
 }
 
+// ListenAndServe starts the HTTP server and shuts it down with the context.
 func (s *Server) ListenAndServe(ctx context.Context, addr string) error {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", s.withCORS(s.handleRoot))
@@ -68,6 +70,7 @@ func (s *Server) ListenAndServe(ctx context.Context, addr string) error {
 	}
 }
 
+// withCORS wraps a handler with permissive local-development CORS headers.
 func (s *Server) withCORS(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Access-Control-Allow-Origin", "*")
@@ -81,6 +84,7 @@ func (s *Server) withCORS(next http.HandlerFunc) http.HandlerFunc {
 	}
 }
 
+// handleRoot returns a small status page for the hybrid backend.
 func (s *Server) handleRoot(w http.ResponseWriter, r *http.Request) {
 	if r.URL.Path != "/" {
 		http.NotFound(w, r)
@@ -90,6 +94,7 @@ func (s *Server) handleRoot(w http.ResponseWriter, r *http.Request) {
 	_, _ = w.Write([]byte("<!doctype html><meta charset=\"utf-8\"><title>StardewSeedSearcher</title><p>Go+C# hybrid backend is running.</p>"))
 }
 
+// handleHealth reports basic backend health and worker count.
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{
 		"status":  "ok",
@@ -98,6 +103,7 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// handleSeasons returns the fixed season list used by the frontend.
 func (s *Server) handleSeasons(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, []map[string]any{
 		{"id": 0, "name": "\u6625"},
@@ -107,6 +113,7 @@ func (s *Server) handleSeasons(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// handleCartItems asks C# for the traveling cart item list.
 func (s *Server) handleCartItems(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
@@ -121,6 +128,7 @@ func (s *Server) handleCartItems(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, resp.Items)
 }
 
+// handleSearch starts an asynchronous seed search run.
 func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
@@ -161,6 +169,7 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{"message": "Search started."})
 }
 
+// handleStop cancels the currently active search run.
 func (s *Server) handleStop(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
@@ -177,6 +186,7 @@ func (s *Server) handleStop(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{"message": "Stop requested."})
 }
 
+// runSearch partitions the seed range and streams worker results to clients.
 func (s *Server) runSearch(ctx context.Context, run *searchRun, raw json.RawMessage, req searchRequest) {
 	started := time.Now()
 	total := req.EndSeed - req.StartSeed + 1
@@ -320,6 +330,7 @@ func (s *Server) runSearch(ctx context.Context, run *searchRun, raw json.RawMess
 	s.mu.Unlock()
 }
 
+// broadcastProgress sends a throttled progress update to WebSocket clients.
 func (s *Server) broadcastProgress(checked int64, total int64, started time.Time, stats []worker.FeatureStat) {
 	elapsed := time.Since(started).Seconds()
 	speed := float64(0)
@@ -362,10 +373,12 @@ type statCounter struct {
 	order  []string
 }
 
+// newStatCounter creates an ordered pass-count accumulator.
 func newStatCounter() *statCounter {
 	return &statCounter{counts: make(map[string]int64)}
 }
 
+// add merges feature statistics while preserving first-seen order.
 func (s *statCounter) add(stats []worker.FeatureStat) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -377,6 +390,7 @@ func (s *statCounter) add(stats []worker.FeatureStat) {
 	}
 }
 
+// snapshot returns the accumulated statistics in stable order.
 func (s *statCounter) snapshot() []worker.FeatureStat {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -388,6 +402,7 @@ func (s *statCounter) snapshot() []worker.FeatureStat {
 	return result
 }
 
+// rawJSON converts raw JSON into a value suitable for rebroadcasting.
 func rawJSON(raw json.RawMessage) any {
 	if len(raw) == 0 {
 		return nil
@@ -399,10 +414,12 @@ func rawJSON(raw json.RawMessage) any {
 	return value
 }
 
+// round1 rounds a float to one decimal place.
 func round1(value float64) float64 {
 	return math.Round(value*10) / 10
 }
 
+// writeJSON writes a JSON response with the given status code.
 func writeJSON(w http.ResponseWriter, status int, value any) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(status)
@@ -411,6 +428,7 @@ func writeJSON(w http.ResponseWriter, status int, value any) {
 	}
 }
 
+// String formats the seed range for logs and diagnostics.
 func (r seedRange) String() string {
 	return fmt.Sprintf("%d-%d", r.start, r.end)
 }

--- a/StardewSeedSearcher/internal/server/server.go
+++ b/StardewSeedSearcher/internal/server/server.go
@@ -1,0 +1,416 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"math"
+	"net/http"
+	"os"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"stardewseedsearcher/internal/worker"
+	"stardewseedsearcher/internal/ws"
+)
+
+type Server struct {
+	pool *worker.Pool
+	hub  *ws.Hub
+
+	mu     sync.Mutex
+	active *searchRun
+}
+
+type searchRun struct {
+	cancel    context.CancelFunc
+	cancelled atomic.Bool
+}
+
+func New(pool *worker.Pool) *Server {
+	return &Server{
+		pool: pool,
+		hub:  ws.NewHub(),
+	}
+}
+
+func (s *Server) ListenAndServe(ctx context.Context, addr string) error {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", s.withCORS(s.handleRoot))
+	mux.HandleFunc("/ws", s.hub.ServeHTTP)
+	mux.HandleFunc("/api/health", s.withCORS(s.handleHealth))
+	mux.HandleFunc("/api/seasons", s.withCORS(s.handleSeasons))
+	mux.HandleFunc("/api/cart-items", s.withCORS(s.handleCartItems))
+	mux.HandleFunc("/api/search", s.withCORS(s.handleSearch))
+	mux.HandleFunc("/api/stop", s.withCORS(s.handleStop))
+
+	server := &http.Server{Addr: addr, Handler: mux}
+	errc := make(chan error, 1)
+	go func() {
+		errc <- server.ListenAndServe()
+	}()
+
+	select {
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		_ = server.Shutdown(shutdownCtx)
+		return nil
+	case err := <-errc:
+		if errors.Is(err, http.ErrServerClosed) {
+			return nil
+		}
+		return err
+	}
+}
+
+func (s *Server) withCORS(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		next(w, r)
+	}
+}
+
+func (s *Server) handleRoot(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" {
+		http.NotFound(w, r)
+		return
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_, _ = w.Write([]byte("<!doctype html><meta charset=\"utf-8\"><title>StardewSeedSearcher</title><p>Go+C# hybrid backend is running.</p>"))
+}
+
+func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]any{
+		"status":  "ok",
+		"version": "go-csharp-hybrid",
+		"workers": s.pool.Len(),
+	})
+}
+
+func (s *Server) handleSeasons(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, []map[string]any{
+		{"id": 0, "name": "\u6625"},
+		{"id": 1, "name": "\u590f"},
+		{"id": 2, "name": "\u79cb"},
+		{"id": 3, "name": "\u51ac"},
+	})
+}
+
+func (s *Server) handleCartItems(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	resp, err := s.pool.CallAt(0, worker.Request{Type: "cartItems"})
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, http.StatusOK, resp.Items)
+}
+
+func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var raw json.RawMessage
+	if err := json.NewDecoder(r.Body).Decode(&raw); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	var req searchRequest
+	if err := json.Unmarshal(raw, &req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if req.EndSeed < req.StartSeed {
+		http.Error(w, "endSeed must be greater than or equal to startSeed", http.StatusBadRequest)
+		return
+	}
+	if req.OutputLimit <= 0 {
+		req.OutputLimit = 20
+	}
+
+	runCtx, cancel := context.WithCancel(context.Background())
+	run := &searchRun{cancel: cancel}
+
+	s.mu.Lock()
+	if s.active != nil {
+		s.active.cancelled.Store(true)
+		s.active.cancel()
+	}
+	s.active = run
+	s.mu.Unlock()
+
+	go s.runSearch(runCtx, run, raw, req)
+	writeJSON(w, http.StatusOK, map[string]string{"message": "Search started."})
+}
+
+func (s *Server) handleStop(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	s.mu.Lock()
+	if s.active != nil {
+		s.active.cancelled.Store(true)
+		s.active.cancel()
+	}
+	s.mu.Unlock()
+
+	writeJSON(w, http.StatusOK, map[string]string{"message": "Stop requested."})
+}
+
+func (s *Server) runSearch(ctx context.Context, run *searchRun, raw json.RawMessage, req searchRequest) {
+	started := time.Now()
+	total := req.EndSeed - req.StartSeed + 1
+	s.hub.Broadcast(map[string]any{"type": "start", "total": total})
+
+	chunkSize := int64(10000)
+	if rawChunk := os.Getenv("SEED_GO_CHUNK"); rawChunk != "" {
+		if parsed, err := strconv.ParseInt(rawChunk, 10, 64); err == nil && parsed > 0 {
+			chunkSize = parsed
+		}
+	}
+
+	jobs := make(chan seedRange, s.pool.Len()*2)
+	results := make(chan worker.Response, s.pool.Len()*2)
+	errs := make(chan error, s.pool.Len())
+
+	var checked atomic.Int64
+	var found atomic.Int64
+	var hitLimit atomic.Bool
+	stats := newStatCounter()
+
+	var wg sync.WaitGroup
+	for i := 0; i < s.pool.Len(); i++ {
+		wg.Add(1)
+		go func(workerIndex int) {
+			defer wg.Done()
+			for job := range jobs {
+				if ctx.Err() != nil || hitLimit.Load() {
+					return
+				}
+
+				remaining := req.OutputLimit - int(found.Load())
+				if remaining <= 0 {
+					hitLimit.Store(true)
+					run.cancel()
+					return
+				}
+
+				resp, err := s.pool.CallAt(workerIndex, worker.Request{
+					Type:       "search",
+					Request:    raw,
+					StartSeed:  job.start,
+					EndSeed:    job.end,
+					MaxResults: remaining,
+				})
+				if err != nil {
+					select {
+					case errs <- err:
+					default:
+					}
+					run.cancel()
+					return
+				}
+
+				select {
+				case results <- resp:
+				case <-ctx.Done():
+					return
+				}
+			}
+		}(i)
+	}
+
+	go func() {
+		defer close(jobs)
+		for start := req.StartSeed; start <= req.EndSeed; start += chunkSize {
+			if ctx.Err() != nil || hitLimit.Load() {
+				return
+			}
+			end := start + chunkSize - 1
+			if end > req.EndSeed || end < start {
+				end = req.EndSeed
+			}
+			select {
+			case jobs <- seedRange{start: start, end: end}:
+			case <-ctx.Done():
+				return
+			}
+			if end == math.MaxInt32 {
+				return
+			}
+		}
+	}()
+
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
+	lastProgress := time.Time{}
+	for resp := range results {
+		currentChecked := checked.Add(resp.CheckedCount)
+		stats.add(resp.FeatureStats)
+
+		for _, match := range resp.Matches {
+			if found.Load() >= int64(req.OutputLimit) {
+				hitLimit.Store(true)
+				run.cancel()
+				break
+			}
+
+			found.Add(1)
+			s.hub.Broadcast(map[string]any{
+				"type":            "found",
+				"seed":            match.Seed,
+				"details":         rawJSON(match.Details),
+				"enabledFeatures": rawJSON(match.EnabledFeatures),
+			})
+		}
+
+		if found.Load() >= int64(req.OutputLimit) {
+			hitLimit.Store(true)
+			run.cancel()
+		}
+
+		if time.Since(lastProgress) >= 500*time.Millisecond || currentChecked >= total || hitLimit.Load() {
+			s.broadcastProgress(currentChecked, total, started, stats.snapshot())
+			lastProgress = time.Now()
+		}
+	}
+
+	select {
+	case err := <-errs:
+		log.Printf("hybrid search failed: %v", err)
+	default:
+	}
+
+	finalChecked := checked.Load()
+	s.broadcastProgress(finalChecked, total, started, stats.snapshot())
+	s.hub.Broadcast(map[string]any{
+		"type":       "complete",
+		"totalFound": found.Load(),
+		"elapsed":    round1(time.Since(started).Seconds()),
+		"cancelled":  run.cancelled.Load() && !hitLimit.Load(),
+	})
+
+	s.mu.Lock()
+	if s.active == run {
+		s.active = nil
+	}
+	s.mu.Unlock()
+}
+
+func (s *Server) broadcastProgress(checked int64, total int64, started time.Time, stats []worker.FeatureStat) {
+	elapsed := time.Since(started).Seconds()
+	speed := float64(0)
+	if elapsed > 0 {
+		speed = float64(checked) / elapsed
+	}
+	progress := float64(0)
+	if total > 0 {
+		progress = float64(checked) / float64(total) * 100
+	}
+	if progress > 100 {
+		progress = 100
+	}
+
+	s.hub.Broadcast(map[string]any{
+		"type":         "progress",
+		"checkedCount": checked,
+		"total":        total,
+		"progress":     math.Round(progress*100) / 100,
+		"speed":        math.Round(speed),
+		"elapsed":      round1(elapsed),
+		"featureStats": stats,
+	})
+}
+
+type searchRequest struct {
+	StartSeed   int64 `json:"startSeed"`
+	EndSeed     int64 `json:"endSeed"`
+	OutputLimit int   `json:"outputLimit"`
+}
+
+type seedRange struct {
+	start int64
+	end   int64
+}
+
+type statCounter struct {
+	mu     sync.Mutex
+	counts map[string]int64
+	order  []string
+}
+
+func newStatCounter() *statCounter {
+	return &statCounter{counts: make(map[string]int64)}
+}
+
+func (s *statCounter) add(stats []worker.FeatureStat) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, stat := range stats {
+		if _, ok := s.counts[stat.Name]; !ok {
+			s.order = append(s.order, stat.Name)
+		}
+		s.counts[stat.Name] += stat.PassCount
+	}
+}
+
+func (s *statCounter) snapshot() []worker.FeatureStat {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	result := make([]worker.FeatureStat, 0, len(s.order))
+	for _, name := range s.order {
+		result = append(result, worker.FeatureStat{Name: name, PassCount: s.counts[name]})
+	}
+	return result
+}
+
+func rawJSON(raw json.RawMessage) any {
+	if len(raw) == 0 {
+		return nil
+	}
+	var value any
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return nil
+	}
+	return value
+}
+
+func round1(value float64) float64 {
+	return math.Round(value*10) / 10
+}
+
+func writeJSON(w http.ResponseWriter, status int, value any) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(value); err != nil {
+		log.Printf("write json response: %v", err)
+	}
+}
+
+func (r seedRange) String() string {
+	return fmt.Sprintf("%d-%d", r.start, r.end)
+}

--- a/StardewSeedSearcher/internal/worker/worker.go
+++ b/StardewSeedSearcher/internal/worker/worker.go
@@ -1,0 +1,239 @@
+package worker
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+)
+
+type Request struct {
+	ID         string          `json:"id,omitempty"`
+	Type       string          `json:"type"`
+	Request    json.RawMessage `json:"request,omitempty"`
+	StartSeed  int64           `json:"startSeed,omitempty"`
+	EndSeed    int64           `json:"endSeed,omitempty"`
+	MaxResults int             `json:"maxResults,omitempty"`
+}
+
+type Response struct {
+	ID           string        `json:"id,omitempty"`
+	Type         string        `json:"type"`
+	CheckedCount int64         `json:"checkedCount,omitempty"`
+	Matches      []SeedMatch   `json:"matches,omitempty"`
+	FeatureStats []FeatureStat `json:"featureStats,omitempty"`
+	Items        []string      `json:"items,omitempty"`
+	Error        string        `json:"error,omitempty"`
+}
+
+type SeedMatch struct {
+	Seed            int             `json:"seed"`
+	Details         json.RawMessage `json:"details,omitempty"`
+	EnabledFeatures json.RawMessage `json:"enabledFeatures,omitempty"`
+}
+
+type FeatureStat struct {
+	Name      string `json:"name"`
+	PassCount int64  `json:"passCount"`
+}
+
+type Pool struct {
+	clients []*Client
+	next    atomic.Uint64
+}
+
+func NewPool(ctx context.Context, size int) (*Pool, error) {
+	if size < 1 {
+		size = 1
+	}
+
+	clients := make([]*Client, 0, size)
+	for i := 0; i < size; i++ {
+		client, err := Start(ctx, i)
+		if err != nil {
+			for _, existing := range clients {
+				existing.Close()
+			}
+			return nil, err
+		}
+		clients = append(clients, client)
+	}
+
+	return &Pool{clients: clients}, nil
+}
+
+func (p *Pool) Len() int {
+	return len(p.clients)
+}
+
+func (p *Pool) Call(req Request) (Response, error) {
+	if len(p.clients) == 0 {
+		return Response{}, errors.New("worker pool is empty")
+	}
+	index := int(p.next.Add(1)-1) % len(p.clients)
+	return p.CallAt(index, req)
+}
+
+func (p *Pool) CallAt(index int, req Request) (Response, error) {
+	if len(p.clients) == 0 {
+		return Response{}, errors.New("worker pool is empty")
+	}
+	index %= len(p.clients)
+	if index < 0 {
+		index += len(p.clients)
+	}
+	return p.clients[index].Call(req)
+}
+
+func (p *Pool) Close() {
+	for _, client := range p.clients {
+		client.Close()
+	}
+}
+
+type Client struct {
+	id     int
+	cmd    *exec.Cmd
+	stdin  io.WriteCloser
+	stdout *bufio.Reader
+	mu     sync.Mutex
+	seq    atomic.Uint64
+}
+
+func Start(ctx context.Context, id int) (*Client, error) {
+	name, args, workDir, err := resolveWorkerCommand()
+	if err != nil {
+		return nil, err
+	}
+
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Dir = workDir
+	cmd.Env = append(os.Environ(), "DOTNET_CLI_TELEMETRY_OPTOUT=1")
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, err
+	}
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+	stderrPipe, err := cmd.StderrPipe()
+	if err != nil {
+		return nil, err
+	}
+
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+
+	client := &Client{
+		id:     id,
+		cmd:    cmd,
+		stdin:  stdin,
+		stdout: bufio.NewReader(stdoutPipe),
+	}
+
+	go logWorkerStderr(id, stderrPipe)
+	go func() {
+		if err := cmd.Wait(); err != nil && ctx.Err() == nil {
+			log.Printf("C# worker %d exited: %v", id, err)
+		}
+	}()
+
+	return client, nil
+}
+
+func (c *Client) Call(req Request) (Response, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if req.ID == "" {
+		req.ID = fmt.Sprintf("w%d-%d", c.id, c.seq.Add(1))
+	}
+
+	payload, err := json.Marshal(req)
+	if err != nil {
+		return Response{}, err
+	}
+
+	if _, err := c.stdin.Write(append(payload, '\n')); err != nil {
+		return Response{}, err
+	}
+
+	line, err := c.stdout.ReadBytes('\n')
+	if err != nil {
+		return Response{}, err
+	}
+
+	var resp Response
+	if err := json.Unmarshal(line, &resp); err != nil {
+		return Response{}, err
+	}
+	if resp.Error != "" {
+		return resp, errors.New(resp.Error)
+	}
+
+	return resp, nil
+}
+
+func (c *Client) Close() {
+	_ = c.stdin.Close()
+	if c.cmd != nil && c.cmd.Process != nil {
+		_ = c.cmd.Process.Kill()
+	}
+}
+
+func resolveWorkerCommand() (string, []string, string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", nil, "", err
+	}
+
+	projectDirs := []string{cwd, filepath.Join(cwd, "StardewSeedSearcher")}
+	for _, dir := range projectDirs {
+		project := filepath.Join(dir, "StardewSeedSearcher.csproj")
+		if _, err := os.Stat(project); err != nil {
+			continue
+		}
+
+		releaseDll := filepath.Join(dir, "bin", "Release", "net9.0", "StardewSeedSearcher.dll")
+		if _, err := os.Stat(releaseDll); err == nil {
+			return "dotnet", []string{releaseDll, "--worker"}, dir, nil
+		}
+
+		debugDll := filepath.Join(dir, "bin", "Debug", "net9.0", "StardewSeedSearcher.dll")
+		if _, err := os.Stat(debugDll); err == nil {
+			return "dotnet", []string{debugDll, "--worker"}, dir, nil
+		}
+
+		log.Printf("C# worker binary was not found; running dotnet build for %s", project)
+		build := exec.Command("dotnet", "build", project)
+		build.Dir = dir
+		build.Env = append(os.Environ(), "DOTNET_CLI_TELEMETRY_OPTOUT=1")
+		if output, err := build.CombinedOutput(); err != nil {
+			return "", nil, "", fmt.Errorf("dotnet build failed: %w\n%s", err, string(output))
+		}
+		if _, err := os.Stat(debugDll); err == nil {
+			return "dotnet", []string{debugDll, "--worker"}, dir, nil
+		}
+		return "", nil, "", fmt.Errorf("dotnet build completed, but %s was not created", debugDll)
+	}
+
+	return "", nil, "", fmt.Errorf("StardewSeedSearcher.csproj was not found under %s", cwd)
+}
+
+func logWorkerStderr(id int, reader io.Reader) {
+	scanner := bufio.NewScanner(reader)
+	for scanner.Scan() {
+		log.Printf("C# worker %d: %s", id, scanner.Text())
+	}
+}

--- a/StardewSeedSearcher/internal/worker/worker.go
+++ b/StardewSeedSearcher/internal/worker/worker.go
@@ -50,6 +50,7 @@ type Pool struct {
 	next    atomic.Uint64
 }
 
+// NewPool starts a pool of long-lived C# worker clients.
 func NewPool(ctx context.Context, size int) (*Pool, error) {
 	if size < 1 {
 		size = 1
@@ -70,10 +71,12 @@ func NewPool(ctx context.Context, size int) (*Pool, error) {
 	return &Pool{clients: clients}, nil
 }
 
+// Len returns the number of workers in the pool.
 func (p *Pool) Len() int {
 	return len(p.clients)
 }
 
+// Call sends a request to the next worker in round-robin order.
 func (p *Pool) Call(req Request) (Response, error) {
 	if len(p.clients) == 0 {
 		return Response{}, errors.New("worker pool is empty")
@@ -82,6 +85,7 @@ func (p *Pool) Call(req Request) (Response, error) {
 	return p.CallAt(index, req)
 }
 
+// CallAt sends a request to the worker at the given index.
 func (p *Pool) CallAt(index int, req Request) (Response, error) {
 	if len(p.clients) == 0 {
 		return Response{}, errors.New("worker pool is empty")
@@ -93,6 +97,7 @@ func (p *Pool) CallAt(index int, req Request) (Response, error) {
 	return p.clients[index].Call(req)
 }
 
+// Close stops all worker clients in the pool.
 func (p *Pool) Close() {
 	for _, client := range p.clients {
 		client.Close()
@@ -108,6 +113,7 @@ type Client struct {
 	seq    atomic.Uint64
 }
 
+// Start launches one C# worker process and wraps it as a client.
 func Start(ctx context.Context, id int) (*Client, error) {
 	name, args, workDir, err := resolveWorkerCommand()
 	if err != nil {
@@ -152,6 +158,7 @@ func Start(ctx context.Context, id int) (*Client, error) {
 	return client, nil
 }
 
+// Call sends one JSON-line request and waits for one JSON-line response.
 func (c *Client) Call(req Request) (Response, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -185,6 +192,7 @@ func (c *Client) Call(req Request) (Response, error) {
 	return resp, nil
 }
 
+// Close terminates the underlying C# worker process.
 func (c *Client) Close() {
 	_ = c.stdin.Close()
 	if c.cmd != nil && c.cmd.Process != nil {
@@ -192,6 +200,7 @@ func (c *Client) Close() {
 	}
 }
 
+// resolveWorkerCommand locates or builds the C# worker entry point.
 func resolveWorkerCommand() (string, []string, string, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -231,6 +240,7 @@ func resolveWorkerCommand() (string, []string, string, error) {
 	return "", nil, "", fmt.Errorf("StardewSeedSearcher.csproj was not found under %s", cwd)
 }
 
+// logWorkerStderr forwards worker stderr lines to the Go logger.
 func logWorkerStderr(id int, reader io.Reader) {
 	scanner := bufio.NewScanner(reader)
 	for scanner.Scan() {

--- a/StardewSeedSearcher/internal/ws/ws.go
+++ b/StardewSeedSearcher/internal/ws/ws.go
@@ -21,10 +21,12 @@ type Hub struct {
 	conns map[*Conn]struct{}
 }
 
+// NewHub creates an empty WebSocket connection hub.
 func NewHub() *Hub {
 	return &Hub{conns: make(map[*Conn]struct{})}
 }
 
+// ServeHTTP upgrades HTTP requests and registers WebSocket clients.
 func (h *Hub) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if !strings.EqualFold(r.Header.Get("Upgrade"), "websocket") {
 		http.Error(w, "websocket upgrade required", http.StatusBadRequest)
@@ -66,6 +68,7 @@ func (h *Hub) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}()
 }
 
+// Broadcast sends a JSON message to all connected clients.
 func (h *Hub) Broadcast(value any) {
 	payload, err := json.Marshal(value)
 	if err != nil {
@@ -87,12 +90,14 @@ func (h *Hub) Broadcast(value any) {
 	}
 }
 
+// add registers a connection in the hub.
 func (h *Hub) add(conn *Conn) {
 	h.mu.Lock()
 	h.conns[conn] = struct{}{}
 	h.mu.Unlock()
 }
 
+// remove unregisters a connection from the hub.
 func (h *Hub) remove(conn *Conn) {
 	h.mu.Lock()
 	delete(h.conns, conn)
@@ -104,6 +109,7 @@ type Conn struct {
 	mu   sync.Mutex
 }
 
+// SendText writes one unmasked text frame to the client.
 func (c *Conn) SendText(payload []byte) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -135,11 +141,13 @@ func (c *Conn) SendText(payload []byte) error {
 	return err
 }
 
+// websocketAccept computes the RFC 6455 accept key.
 func websocketAccept(key string) string {
 	sum := sha1.Sum([]byte(key + acceptGUID))
 	return base64.StdEncoding.EncodeToString(sum[:])
 }
 
+// readLoop drains client frames until the socket closes.
 func readLoop(reader *bufio.Reader, conn net.Conn) {
 	for {
 		first, err := reader.ReadByte()

--- a/StardewSeedSearcher/internal/ws/ws.go
+++ b/StardewSeedSearcher/internal/ws/ws.go
@@ -1,0 +1,189 @@
+package ws
+
+import (
+	"bufio"
+	"crypto/sha1"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+)
+
+const acceptGUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+
+type Hub struct {
+	mu    sync.Mutex
+	conns map[*Conn]struct{}
+}
+
+func NewHub() *Hub {
+	return &Hub{conns: make(map[*Conn]struct{})}
+}
+
+func (h *Hub) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if !strings.EqualFold(r.Header.Get("Upgrade"), "websocket") {
+		http.Error(w, "websocket upgrade required", http.StatusBadRequest)
+		return
+	}
+
+	key := r.Header.Get("Sec-WebSocket-Key")
+	if key == "" {
+		http.Error(w, "missing Sec-WebSocket-Key", http.StatusBadRequest)
+		return
+	}
+
+	hijacker, ok := w.(http.Hijacker)
+	if !ok {
+		http.Error(w, "hijacking is not supported", http.StatusInternalServerError)
+		return
+	}
+
+	conn, rw, err := hijacker.Hijack()
+	if err != nil {
+		return
+	}
+
+	accept := websocketAccept(key)
+	_, _ = fmt.Fprintf(rw, "HTTP/1.1 101 Switching Protocols\r\n")
+	_, _ = fmt.Fprintf(rw, "Upgrade: websocket\r\n")
+	_, _ = fmt.Fprintf(rw, "Connection: Upgrade\r\n")
+	_, _ = fmt.Fprintf(rw, "Sec-WebSocket-Accept: %s\r\n\r\n", accept)
+	_ = rw.Flush()
+
+	client := &Conn{conn: conn}
+	h.add(client)
+	go func() {
+		defer func() {
+			h.remove(client)
+			_ = conn.Close()
+		}()
+		readLoop(rw.Reader, conn)
+	}()
+}
+
+func (h *Hub) Broadcast(value any) {
+	payload, err := json.Marshal(value)
+	if err != nil {
+		return
+	}
+
+	h.mu.Lock()
+	conns := make([]*Conn, 0, len(h.conns))
+	for conn := range h.conns {
+		conns = append(conns, conn)
+	}
+	h.mu.Unlock()
+
+	for _, conn := range conns {
+		if err := conn.SendText(payload); err != nil {
+			h.remove(conn)
+			_ = conn.conn.Close()
+		}
+	}
+}
+
+func (h *Hub) add(conn *Conn) {
+	h.mu.Lock()
+	h.conns[conn] = struct{}{}
+	h.mu.Unlock()
+}
+
+func (h *Hub) remove(conn *Conn) {
+	h.mu.Lock()
+	delete(h.conns, conn)
+	h.mu.Unlock()
+}
+
+type Conn struct {
+	conn net.Conn
+	mu   sync.Mutex
+}
+
+func (c *Conn) SendText(payload []byte) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	header := make([]byte, 10)
+	header[0] = 0x81
+	length := len(payload)
+
+	switch {
+	case length <= 125:
+		header[1] = byte(length)
+		_, err := c.conn.Write(append(header[:2], payload...))
+		return err
+	case length <= 65535:
+		header[1] = 126
+		binary.BigEndian.PutUint16(header[2:4], uint16(length))
+		if _, err := c.conn.Write(header[:4]); err != nil {
+			return err
+		}
+	default:
+		header[1] = 127
+		binary.BigEndian.PutUint64(header[2:10], uint64(length))
+		if _, err := c.conn.Write(header[:10]); err != nil {
+			return err
+		}
+	}
+
+	_, err := c.conn.Write(payload)
+	return err
+}
+
+func websocketAccept(key string) string {
+	sum := sha1.Sum([]byte(key + acceptGUID))
+	return base64.StdEncoding.EncodeToString(sum[:])
+}
+
+func readLoop(reader *bufio.Reader, conn net.Conn) {
+	for {
+		first, err := reader.ReadByte()
+		if err != nil {
+			return
+		}
+		second, err := reader.ReadByte()
+		if err != nil {
+			return
+		}
+
+		opcode := first & 0x0f
+		masked := second&0x80 != 0
+		length := uint64(second & 0x7f)
+
+		switch length {
+		case 126:
+			var buf [2]byte
+			if _, err := io.ReadFull(reader, buf[:]); err != nil {
+				return
+			}
+			length = uint64(binary.BigEndian.Uint16(buf[:]))
+		case 127:
+			var buf [8]byte
+			if _, err := io.ReadFull(reader, buf[:]); err != nil {
+				return
+			}
+			length = binary.BigEndian.Uint64(buf[:])
+		}
+
+		var mask [4]byte
+		if masked {
+			if _, err := io.ReadFull(reader, mask[:]); err != nil {
+				return
+			}
+		}
+
+		if _, err := io.CopyN(io.Discard, reader, int64(length)); err != nil {
+			return
+		}
+
+		if opcode == 0x8 {
+			_, _ = conn.Write([]byte{0x88, 0x00})
+			return
+		}
+	}
+}

--- a/StardewSeedSearcher/main.go
+++ b/StardewSeedSearcher/main.go
@@ -35,7 +35,7 @@ func main() {
 
 	addr := strings.TrimSpace(os.Getenv("SEED_GO_ADDR"))
 	if addr == "" {
-		addr = "localhost:5000"
+		addr = "localhost:5050"
 	}
 
 	app := server.New(pool)

--- a/StardewSeedSearcher/main.go
+++ b/StardewSeedSearcher/main.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+	"os/signal"
+	"runtime"
+	"stardewseedsearcher/internal/server"
+	"stardewseedsearcher/internal/worker"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+func main() {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	workerCount := runtime.NumCPU() - 1
+	if workerCount < 1 {
+		workerCount = 1
+	}
+	if raw := strings.TrimSpace(os.Getenv("SEED_GO_WORKERS")); raw != "" {
+		if parsed, err := strconv.Atoi(raw); err == nil && parsed > 0 {
+			workerCount = parsed
+		}
+	}
+
+	pool, err := worker.NewPool(ctx, workerCount)
+	if err != nil {
+		log.Fatalf("start C# workers: %v", err)
+	}
+	defer pool.Close()
+
+	addr := strings.TrimSpace(os.Getenv("SEED_GO_ADDR"))
+	if addr == "" {
+		addr = "localhost:5000"
+	}
+
+	app := server.New(pool)
+	log.Printf("Go+C# hybrid backend listening on http://%s with %d C# workers", addr, pool.Len())
+	if err := app.ListenAndServe(ctx, addr); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/StardewSeedSearcher/main.go
+++ b/StardewSeedSearcher/main.go
@@ -33,6 +33,7 @@ func main() {
 	}
 	defer pool.Close()
 
+	// set addr via os.env
 	addr := strings.TrimSpace(os.Getenv("SEED_GO_ADDR"))
 	if addr == "" {
 		addr = "localhost:5050"

--- a/index.html
+++ b/index.html
@@ -10,7 +10,23 @@
 </head>
 
 <body>
-    <div class="connection-status" id="connectionStatus">连接中...</div>
+    <div class="connection-widget">
+        <div class="connection-status" id="connectionStatus">连接中...</div>
+        <button type="button" class="backend-toggle" id="backendToggle" aria-label="后端设置" title="后端设置">⚙</button>
+        <div class="backend-popover" id="backendPopover">
+            <div class="backend-field">
+                <label for="backendMode">后端模式</label>
+                <select id="backendMode">
+                    <option value="csharp">纯 C#</option>
+                    <option value="hybrid">Go + C# 混合</option>
+                </select>
+            </div>
+            <div class="backend-field">
+                <label for="backendCustomOrigin">端口地址</label>
+                <input type="text" id="backendCustomOrigin" placeholder="http://localhost:5050">
+            </div>
+        </div>
+    </div>
 
     <div class="container">
         <div class="header">

--- a/index.html
+++ b/index.html
@@ -10,20 +10,19 @@
 </head>
 
 <body>
-    <div class="connection-widget">
-        <div class="connection-status" id="connectionStatus">连接中...</div>
-        <button type="button" class="backend-toggle" id="backendToggle" aria-label="后端设置" title="后端设置">⚙</button>
-        <div class="backend-popover" id="backendPopover">
-            <div class="backend-field">
-                <label for="backendMode">后端模式</label>
-                <select id="backendMode">
-                    <option value="csharp">纯 C#</option>
-                    <option value="hybrid">Go + C# 混合</option>
-                </select>
+    <div class="connection-widget" id="connectionWidget">
+        <div class="connection-pill connecting" id="connectionPill">
+            <div class="connection-status connecting" id="connectionStatus">连接中...</div>
+            <button type="button" class="backend-toggle" id="backendToggle" aria-label="选择后端" title="选择后端"></button>
+        </div>
+        <div class="backend-popover" id="backendPopover" aria-label="后端选择面板">
+            <div class="backend-option" data-backend-mode="csharp">
+                <button type="button" class="backend-option-label" data-backend-mode="csharp">C#:</button>
+                <input type="text" class="backend-origin-input" id="backendOriginCsharp" data-backend-mode="csharp" value="http://localhost:5000" aria-label="C# 后端地址">
             </div>
-            <div class="backend-field">
-                <label for="backendCustomOrigin">端口地址</label>
-                <input type="text" id="backendCustomOrigin" placeholder="http://localhost:5050">
+            <div class="backend-option" data-backend-mode="hybrid">
+                <button type="button" class="backend-option-label" data-backend-mode="hybrid">Go＆C#:</button>
+                <input type="text" class="backend-origin-input" id="backendOriginHybrid" data-backend-mode="hybrid" value="http://localhost:5050" aria-label="Go 与 C# 混合后端地址">
             </div>
         </div>
     </div>

--- a/script.js
+++ b/script.js
@@ -29,38 +29,76 @@ const DEFAULT_BACKEND_ORIGIN = 'http://localhost:5000';
 const HYBRID_BACKEND_ORIGIN = 'http://localhost:5050';
 const BACKEND_STORAGE_KEY = 'stardewSeedSearcher.backendOrigin';
 const BACKEND_MODE_STORAGE_KEY = 'stardewSeedSearcher.backendMode';
+const BACKEND_ORIGINS_STORAGE_KEY = 'stardewSeedSearcher.backendOrigins';
 
-function normalizeBackendOrigin(value) {
+function getBackendDefaultOrigin(mode) {
+    return mode === 'hybrid' ? HYBRID_BACKEND_ORIGIN : DEFAULT_BACKEND_ORIGIN;
+}
+
+function normalizeBackendOrigin(value, fallback = DEFAULT_BACKEND_ORIGIN) {
     const raw = (value || '').trim();
-    if (!raw) return DEFAULT_BACKEND_ORIGIN;
+    if (!raw) return fallback;
 
     const withProtocol = /^https?:\/\//i.test(raw) ? raw : `http://${raw}`;
     try {
         const url = new URL(withProtocol);
         return url.origin;
     } catch {
-        return DEFAULT_BACKEND_ORIGIN;
+        return fallback;
     }
 }
 
-function loadBackendOrigin() {
+function loadBackendSettings() {
+    const savedMode = localStorage.getItem(BACKEND_MODE_STORAGE_KEY);
+    let mode = savedMode === 'hybrid' ? 'hybrid' : 'csharp';
+    const origins = {
+        csharp: DEFAULT_BACKEND_ORIGIN,
+        hybrid: HYBRID_BACKEND_ORIGIN
+    };
+
+    try {
+        const savedOrigins = JSON.parse(localStorage.getItem(BACKEND_ORIGINS_STORAGE_KEY) || '{}');
+        if (savedOrigins && typeof savedOrigins === 'object') {
+            if (savedOrigins.csharp) {
+                origins.csharp = normalizeBackendOrigin(savedOrigins.csharp, DEFAULT_BACKEND_ORIGIN);
+            }
+            if (savedOrigins.hybrid) {
+                origins.hybrid = normalizeBackendOrigin(savedOrigins.hybrid, HYBRID_BACKEND_ORIGIN);
+            }
+        }
+    } catch {
+        // 忽略损坏的本地配置，继续使用默认地址。
+    }
+
+    const oldOrigin = localStorage.getItem(BACKEND_STORAGE_KEY);
+    if (oldOrigin) {
+        const guessedMode = oldOrigin === HYBRID_BACKEND_ORIGIN ? 'hybrid' : oldOrigin === DEFAULT_BACKEND_ORIGIN ? 'csharp' : mode;
+        origins[guessedMode] = normalizeBackendOrigin(oldOrigin, getBackendDefaultOrigin(guessedMode));
+        mode = guessedMode;
+    }
+
     const params = new URLSearchParams(window.location.search);
     const fromQuery = params.get('backend') || params.get('api');
     if (fromQuery) {
-        const origin = normalizeBackendOrigin(fromQuery);
-        localStorage.setItem(BACKEND_STORAGE_KEY, origin);
-        return origin;
+        const origin = normalizeBackendOrigin(fromQuery, getBackendDefaultOrigin(mode));
+        mode = origin === HYBRID_BACKEND_ORIGIN ? 'hybrid' : origin === DEFAULT_BACKEND_ORIGIN ? 'csharp' : mode;
+        origins[mode] = origin;
     }
 
-    return normalizeBackendOrigin(localStorage.getItem(BACKEND_STORAGE_KEY) || DEFAULT_BACKEND_ORIGIN);
+    return { mode, origins };
 }
 
-let backendOrigin = loadBackendOrigin();
-let backendMode = backendOrigin === HYBRID_BACKEND_ORIGIN
-    ? 'hybrid'
-    : backendOrigin === DEFAULT_BACKEND_ORIGIN
-        ? 'csharp'
-        : (localStorage.getItem(BACKEND_MODE_STORAGE_KEY) || 'csharp');
+function saveBackendSettings() {
+    localStorage.setItem(BACKEND_MODE_STORAGE_KEY, backendMode);
+    localStorage.setItem(BACKEND_STORAGE_KEY, backendOrigin);
+    localStorage.setItem(BACKEND_ORIGINS_STORAGE_KEY, JSON.stringify(backendOrigins));
+}
+
+const backendSettings = loadBackendSettings();
+let backendOrigins = backendSettings.origins;
+let backendMode = backendSettings.mode;
+let backendOrigin = backendOrigins[backendMode] || getBackendDefaultOrigin(backendMode);
+saveBackendSettings();
 
 function apiUrl(path) {
     return `${backendOrigin}${path}`;
@@ -74,17 +112,27 @@ function webSocketUrl(path) {
 
 function setBackendMode(mode, shouldReconnect = true) {
     backendMode = mode === 'hybrid' ? 'hybrid' : 'csharp';
-    localStorage.setItem(BACKEND_MODE_STORAGE_KEY, backendMode);
-
-    const modeDefault = backendMode === 'hybrid' ? HYBRID_BACKEND_ORIGIN : DEFAULT_BACKEND_ORIGIN;
-    const otherDefault = backendMode === 'hybrid' ? DEFAULT_BACKEND_ORIGIN : HYBRID_BACKEND_ORIGIN;
-    if (!backendOrigin || backendOrigin === otherDefault) {
-        backendOrigin = modeDefault;
-        localStorage.setItem(BACKEND_STORAGE_KEY, backendOrigin);
-    }
+    backendOrigin = backendOrigins[backendMode] || getBackendDefaultOrigin(backendMode);
+    saveBackendSettings();
 
     updateBackendControls();
     if (shouldReconnect) {
+        reconnectBackend();
+    }
+}
+
+function setBackendOriginForMode(mode, value, shouldReconnect = true) {
+    const nextMode = mode === 'hybrid' ? 'hybrid' : 'csharp';
+    backendOrigins[nextMode] = normalizeBackendOrigin(value, getBackendDefaultOrigin(nextMode));
+
+    if (backendMode === nextMode) {
+        backendOrigin = backendOrigins[nextMode];
+    }
+
+    saveBackendSettings();
+    updateBackendControls();
+
+    if (shouldReconnect && backendMode === nextMode) {
         reconnectBackend();
     }
 }
@@ -147,53 +195,98 @@ const elements = {
 };
 
 function updateBackendControls() {
-    const mode = document.getElementById('backendMode');
-    const custom = document.getElementById('backendCustomOrigin');
-    if (!mode || !custom) return;
+    const csharpInput = document.getElementById('backendOriginCsharp');
+    const hybridInput = document.getElementById('backendOriginHybrid');
+    const popover = document.getElementById('backendPopover');
+    const widget = document.getElementById('connectionWidget');
+    if (!csharpInput || !hybridInput) return;
 
-    mode.value = backendMode;
-    custom.value = backendOrigin;
-    custom.style.display = 'block';
+    csharpInput.value = backendOrigins.csharp || DEFAULT_BACKEND_ORIGIN;
+    hybridInput.value = backendOrigins.hybrid || HYBRID_BACKEND_ORIGIN;
+
+    document.querySelectorAll('.backend-option').forEach(option => {
+        option.classList.toggle('active', option.dataset.backendMode === backendMode);
+    });
+
+    if (widget && popover) {
+        widget.classList.toggle('open', popover.classList.contains('open'));
+    }
+}
+
+function setBackendPopoverOpen(isOpen) {
+    const widget = document.getElementById('connectionWidget');
+    const popover = document.getElementById('backendPopover');
+    const toggle = document.getElementById('backendToggle');
+    if (!popover) return;
+
+    popover.classList.toggle('open', isOpen);
+    if (widget) widget.classList.toggle('open', isOpen);
+    if (toggle) toggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
 }
 
 function initializeBackendControls() {
-    const mode = document.getElementById('backendMode');
-    const custom = document.getElementById('backendCustomOrigin');
     const toggle = document.getElementById('backendToggle');
     const popover = document.getElementById('backendPopover');
-    if (!mode || !custom) return;
+    const originInputs = document.querySelectorAll('.backend-origin-input');
+    const backendOptions = document.querySelectorAll('.backend-option');
+    if (!toggle || !popover || originInputs.length === 0) return;
 
     updateBackendControls();
 
-    mode.addEventListener('change', () => {
-        backendOrigin = mode.value === 'hybrid' ? HYBRID_BACKEND_ORIGIN : DEFAULT_BACKEND_ORIGIN;
-        localStorage.setItem(BACKEND_STORAGE_KEY, backendOrigin);
-        setBackendMode(mode.value);
-    });
-
-    custom.addEventListener('change', () => {
-        backendOrigin = normalizeBackendOrigin(custom.value);
-        localStorage.setItem(BACKEND_STORAGE_KEY, backendOrigin);
-        updateBackendControls();
-        reconnectBackend();
-    });
-
-    if (toggle && popover) {
-        toggle.addEventListener('click', (event) => {
-            event.stopPropagation();
-            popover.classList.toggle('open');
+    backendOptions.forEach(option => {
+        option.addEventListener('click', () => {
+            setBackendMode(option.dataset.backendMode);
         });
+    });
 
-        popover.addEventListener('click', (event) => {
+    originInputs.forEach(input => {
+        input.addEventListener('click', (event) => {
+            // 点击地址框时仍然保留面板，不触发页面外点击关闭。
             event.stopPropagation();
         });
 
-        document.addEventListener('click', () => {
-            popover.classList.remove('open');
+        input.addEventListener('focus', () => {
+            setBackendMode(input.dataset.backendMode);
         });
-    }
+
+        input.addEventListener('change', () => {
+            setBackendOriginForMode(input.dataset.backendMode, input.value);
+        });
+
+        input.addEventListener('keydown', (event) => {
+            if (event.key === 'Enter') {
+                input.blur();
+            }
+        });
+    });
+
+    toggle.addEventListener('click', (event) => {
+        event.stopPropagation();
+        setBackendPopoverOpen(!popover.classList.contains('open'));
+    });
+
+    popover.addEventListener('click', (event) => {
+        event.stopPropagation();
+    });
+
+    document.addEventListener('click', () => {
+        setBackendPopoverOpen(false);
+    });
 
     setBackendMode(backendMode, false);
+}
+
+function updateConnectionState(text, state) {
+    const pill = document.getElementById('connectionPill');
+    const normalizedState = ['connected', 'disconnected', 'connecting'].includes(state) ? state : 'connecting';
+
+    elements.connectionStatus.textContent = text;
+    elements.connectionStatus.className = `connection-status ${normalizedState}`;
+
+    if (pill) {
+        pill.classList.remove('connected', 'disconnected', 'connecting');
+        pill.classList.add(normalizedState);
+    }
 }
 
 // 混合宝箱数据
@@ -714,16 +807,14 @@ function connectWebSocket() {
         }
     }
 
-    elements.connectionStatus.textContent = '连接中...';
-    elements.connectionStatus.className = 'connection-status connecting';
+    updateConnectionState('连接中...', 'connecting');
 
     const socket = new WebSocket(webSocketUrl('/ws'));
     ws = socket;
 
     socket.onopen = () => {
         if (token !== wsConnectionToken || socket !== ws) return;
-        elements.connectionStatus.textContent = '✓ 已连接';
-        elements.connectionStatus.className = 'connection-status connected';
+        updateConnectionState('✓ 已连接', 'connected');
     };
 
     socket.onmessage = (event) => {
@@ -734,14 +825,12 @@ function connectWebSocket() {
 
     socket.onerror = () => {
         if (token !== wsConnectionToken || socket !== ws) return;
-        elements.connectionStatus.textContent = '✗ 连接失败';
-        elements.connectionStatus.className = 'connection-status disconnected';
+        updateConnectionState('✗ 连接失败', 'disconnected');
     };
 
     socket.onclose = () => {
         if (token !== wsConnectionToken || socket !== ws) return;
-        elements.connectionStatus.textContent = '✗ 未连接';
-        elements.connectionStatus.className = 'connection-status disconnected';
+        updateConnectionState('✗ 未连接', 'disconnected');
         wsReconnectTimer = setTimeout(connectWebSocket, 5000);
     };
 }

--- a/script.js
+++ b/script.js
@@ -1,6 +1,9 @@
 let ws = null;
+let wsConnectionToken = 0;
+let wsReconnectTimer = null;
 let isSearching = false;
 let foundSeeds = [];
+let foundSeedSet = new Set();
 let currentSearchUseLegacy = false;
 let seedDetailsCache = {};
 let nextStartSeed = 0;
@@ -17,6 +20,86 @@ let monsterLevelConditions = [];
 let nextMonsterLevelIndex = 1;
 
 let ALL_CART_ITEM_NAMES = [];
+let pendingAnalysisUpdate = null;
+let analysisUpdateTimer = null;
+let lastAnalysisRenderTime = 0;
+const ANALYSIS_RENDER_INTERVAL = 500;
+
+const DEFAULT_BACKEND_ORIGIN = 'http://localhost:5000';
+const HYBRID_BACKEND_ORIGIN = 'http://localhost:5050';
+const BACKEND_STORAGE_KEY = 'stardewSeedSearcher.backendOrigin';
+const BACKEND_MODE_STORAGE_KEY = 'stardewSeedSearcher.backendMode';
+
+function normalizeBackendOrigin(value) {
+    const raw = (value || '').trim();
+    if (!raw) return DEFAULT_BACKEND_ORIGIN;
+
+    const withProtocol = /^https?:\/\//i.test(raw) ? raw : `http://${raw}`;
+    try {
+        const url = new URL(withProtocol);
+        return url.origin;
+    } catch {
+        return DEFAULT_BACKEND_ORIGIN;
+    }
+}
+
+function loadBackendOrigin() {
+    const params = new URLSearchParams(window.location.search);
+    const fromQuery = params.get('backend') || params.get('api');
+    if (fromQuery) {
+        const origin = normalizeBackendOrigin(fromQuery);
+        localStorage.setItem(BACKEND_STORAGE_KEY, origin);
+        return origin;
+    }
+
+    return normalizeBackendOrigin(localStorage.getItem(BACKEND_STORAGE_KEY) || DEFAULT_BACKEND_ORIGIN);
+}
+
+let backendOrigin = loadBackendOrigin();
+let backendMode = backendOrigin === HYBRID_BACKEND_ORIGIN
+    ? 'hybrid'
+    : backendOrigin === DEFAULT_BACKEND_ORIGIN
+        ? 'csharp'
+        : (localStorage.getItem(BACKEND_MODE_STORAGE_KEY) || 'csharp');
+
+function apiUrl(path) {
+    return `${backendOrigin}${path}`;
+}
+
+function webSocketUrl(path) {
+    const url = new URL(path, backendOrigin);
+    url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
+    return url.toString();
+}
+
+function setBackendMode(mode, shouldReconnect = true) {
+    backendMode = mode === 'hybrid' ? 'hybrid' : 'csharp';
+    localStorage.setItem(BACKEND_MODE_STORAGE_KEY, backendMode);
+
+    const modeDefault = backendMode === 'hybrid' ? HYBRID_BACKEND_ORIGIN : DEFAULT_BACKEND_ORIGIN;
+    const otherDefault = backendMode === 'hybrid' ? DEFAULT_BACKEND_ORIGIN : HYBRID_BACKEND_ORIGIN;
+    if (!backendOrigin || backendOrigin === otherDefault) {
+        backendOrigin = modeDefault;
+        localStorage.setItem(BACKEND_STORAGE_KEY, backendOrigin);
+    }
+
+    updateBackendControls();
+    if (shouldReconnect) {
+        reconnectBackend();
+    }
+}
+
+function reconnectBackend() {
+    if (ws) {
+        ws.onopen = null;
+        ws.onmessage = null;
+        ws.onerror = null;
+        ws.onclose = null;
+        ws.close();
+    }
+    connectWebSocket();
+    loadCartItems();
+}
 
 const elements = {
     form: document.getElementById('searchForm'),
@@ -62,6 +145,56 @@ const elements = {
     cartConditionsContainer: document.getElementById('cartConditionsContainer'),
     cartConditionError: document.getElementById('cartConditionError')
 };
+
+function updateBackendControls() {
+    const mode = document.getElementById('backendMode');
+    const custom = document.getElementById('backendCustomOrigin');
+    if (!mode || !custom) return;
+
+    mode.value = backendMode;
+    custom.value = backendOrigin;
+    custom.style.display = 'block';
+}
+
+function initializeBackendControls() {
+    const mode = document.getElementById('backendMode');
+    const custom = document.getElementById('backendCustomOrigin');
+    const toggle = document.getElementById('backendToggle');
+    const popover = document.getElementById('backendPopover');
+    if (!mode || !custom) return;
+
+    updateBackendControls();
+
+    mode.addEventListener('change', () => {
+        backendOrigin = mode.value === 'hybrid' ? HYBRID_BACKEND_ORIGIN : DEFAULT_BACKEND_ORIGIN;
+        localStorage.setItem(BACKEND_STORAGE_KEY, backendOrigin);
+        setBackendMode(mode.value);
+    });
+
+    custom.addEventListener('change', () => {
+        backendOrigin = normalizeBackendOrigin(custom.value);
+        localStorage.setItem(BACKEND_STORAGE_KEY, backendOrigin);
+        updateBackendControls();
+        reconnectBackend();
+    });
+
+    if (toggle && popover) {
+        toggle.addEventListener('click', (event) => {
+            event.stopPropagation();
+            popover.classList.toggle('open');
+        });
+
+        popover.addEventListener('click', (event) => {
+            event.stopPropagation();
+        });
+
+        document.addEventListener('click', () => {
+            popover.classList.remove('open');
+        });
+    }
+
+    setBackendMode(backendMode, false);
+}
 
 // 混合宝箱数据
 const MINE_CHEST_ITEMS = {
@@ -396,7 +529,7 @@ function validateMonsterLevelCondition(condition) {
 // 加载所有猪车物品列表
 async function loadCartItems() {
     try {
-        const response = await fetch('http://localhost:5000/api/cart-items');
+        const response = await fetch(apiUrl('/api/cart-items'));
         ALL_CART_ITEM_NAMES = await response.json();
         initializeCartItemList(); // 更新datalist
     } catch (error) {
@@ -519,6 +652,7 @@ function updateOutputLimitMax() {
 document.addEventListener('DOMContentLoaded', function () {
 
     // 天气条件初始化
+    initializeBackendControls();
     addWeatherCondition();
 
     // 仙子条件初始化
@@ -565,30 +699,50 @@ document.addEventListener('DOMContentLoaded', updateOutputLimitMax);
 document.getElementById('startSeed').addEventListener('change', updateOutputLimitMax);
 
 function connectWebSocket() {
+    const token = ++wsConnectionToken;
+    if (wsReconnectTimer) {
+        clearTimeout(wsReconnectTimer);
+        wsReconnectTimer = null;
+    }
+    if (ws) {
+        ws.onopen = null;
+        ws.onmessage = null;
+        ws.onerror = null;
+        ws.onclose = null;
+        if (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING) {
+            ws.close();
+        }
+    }
+
     elements.connectionStatus.textContent = '连接中...';
     elements.connectionStatus.className = 'connection-status connecting';
 
-    ws = new WebSocket('ws://localhost:5000/ws');
+    const socket = new WebSocket(webSocketUrl('/ws'));
+    ws = socket;
 
-    ws.onopen = () => {
+    socket.onopen = () => {
+        if (token !== wsConnectionToken || socket !== ws) return;
         elements.connectionStatus.textContent = '✓ 已连接';
         elements.connectionStatus.className = 'connection-status connected';
     };
 
-    ws.onmessage = (event) => {
+    socket.onmessage = (event) => {
+        if (token !== wsConnectionToken || socket !== ws) return;
         const data = JSON.parse(event.data);
         handleWebSocketMessage(data);
     };
 
-    ws.onerror = () => {
+    socket.onerror = () => {
+        if (token !== wsConnectionToken || socket !== ws) return;
         elements.connectionStatus.textContent = '✗ 连接失败';
         elements.connectionStatus.className = 'connection-status disconnected';
     };
 
-    ws.onclose = () => {
+    socket.onclose = () => {
+        if (token !== wsConnectionToken || socket !== ws) return;
         elements.connectionStatus.textContent = '✗ 未连接';
         elements.connectionStatus.className = 'connection-status disconnected';
-        setTimeout(connectWebSocket, 5000);
+        wsReconnectTimer = setTimeout(connectWebSocket, 5000);
     };
 }
 
@@ -596,6 +750,7 @@ function handleWebSocketMessage(data) {
     switch (data.type) {
         case 'start':
             foundSeeds = [];
+            foundSeedSet.clear();
             elements.seedList.innerHTML = '';
             elements.resultsSection.style.display = 'block';
 
@@ -605,7 +760,7 @@ function handleWebSocketMessage(data) {
             document.getElementById('analysisStoppedEarly').textContent = '?';
             document.getElementById('analysisStoppedEarly').style.color = '#999';
 
-            const filterStatsList = document.getElementById('filterstatsList');
+            const filterStatsList = document.getElementById('filterStatsList');
             if (filterStatsList) { filterStatsList.innerHTML = ''; }
             break;
 
@@ -626,11 +781,15 @@ function handleWebSocketMessage(data) {
             elements.progressBar.textContent = progressInt + '%';
             //把统计更新掉
             if (data.featureStats && data.featureStats.length > 0) {
-                updateAnalysisUI(data.featureStats, data.checkedCount, foundSeeds.length);
+                scheduleAnalysisUpdate(data.featureStats, data.checkedCount, foundSeeds.length);
             }
             break;
 
         case 'found':
+            if (foundSeedSet.has(data.seed)) {
+                break;
+            }
+            foundSeedSet.add(data.seed);
             foundSeeds.push(data.seed);
             elements.foundCount.textContent = foundSeeds.length;
 
@@ -659,6 +818,7 @@ function handleWebSocketMessage(data) {
             break;
 
         case 'complete':
+            flushPendingAnalysisUpdate();
             elements.statusMessage.textContent = data.cancelled
                 ? `搜索已停止，共找到 ${data.totalFound} 个符合条件的种子`
                 : `搜索完成！找到 ${data.totalFound} 个符合条件的种子`;
@@ -708,6 +868,18 @@ function updateResultsSummary() {
 /**
  * 导出结果到 TXT 文件
  */
+function normalizeCartMatch(match) {
+    return {
+        Year: match.Year ?? match.year,
+        Season: match.Season ?? match.season,
+        Day: match.Day ?? match.day,
+        AbsoluteDay: match.AbsoluteDay ?? match.absoluteDay,
+        ItemName: match.ItemName ?? match.itemName,
+        Quantity: match.Quantity ?? match.quantity,
+        Price: match.Price ?? match.price
+    };
+}
+
 function exportResultsToTxt() {
     if (foundSeeds.length === 0) {
         alert("没有可导出的种子结果！");
@@ -845,7 +1017,7 @@ elements.form.addEventListener('submit', async (e) => {
 
     // 如果正在搜索，点击按钮则停止搜索
     if (isSearching) {
-        await fetch('http://localhost:5000/api/stop', { method: 'POST' });
+        await fetch(apiUrl('/api/stop'), { method: 'POST' });
         return;
     }
 
@@ -1117,7 +1289,7 @@ elements.form.addEventListener('submit', async (e) => {
 
     // 发送搜索请求
     try {
-        const response = await fetch('http://localhost:5000/api/search', {
+        const response = await fetch(apiUrl('/api/search'), {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json'
@@ -1326,7 +1498,7 @@ function showSeedDetail(seed) {
     if (enabled.cart && details.cart && details.cart.matches && details.cart.matches.length > 0) {
 
         // 1. 按AbsoluteDay升序排序，确保展示顺序正确
-        const sortedMatches = [...details.cart.matches].sort((a, b) => a.AbsoluteDay - b.AbsoluteDay);
+        const sortedMatches = details.cart.matches.map(normalizeCartMatch).sort((a, b) => a.AbsoluteDay - b.AbsoluteDay);
 
         // 2. 按物品名分组（保持首次出现顺序）
         const groupMap = new Map();
@@ -1434,6 +1606,34 @@ document.addEventListener('DOMContentLoaded', function () {
         });
     }
 });
+
+function scheduleAnalysisUpdate(stats, currentChecked, totalFound) {
+    pendingAnalysisUpdate = { stats, currentChecked, totalFound };
+    const now = performance.now();
+    const remaining = ANALYSIS_RENDER_INTERVAL - (now - lastAnalysisRenderTime);
+
+    if (remaining <= 0) {
+        flushPendingAnalysisUpdate();
+        return;
+    }
+
+    if (!analysisUpdateTimer) {
+        analysisUpdateTimer = setTimeout(flushPendingAnalysisUpdate, remaining);
+    }
+}
+
+function flushPendingAnalysisUpdate() {
+    if (analysisUpdateTimer) {
+        clearTimeout(analysisUpdateTimer);
+        analysisUpdateTimer = null;
+    }
+    if (!pendingAnalysisUpdate) return;
+
+    const update = pendingAnalysisUpdate;
+    pendingAnalysisUpdate = null;
+    lastAnalysisRenderTime = performance.now();
+    updateAnalysisUI(update.stats, update.currentChecked, update.totalFound);
+}
 
 function updateAnalysisUI(stats, currentChecked, totalFound) {
     document.getElementById('analysisTotalRange').textContent = currentChecked.toLocaleString();

--- a/style.css
+++ b/style.css
@@ -117,6 +117,7 @@ body {
 }
 
 .form-group input[type="number"],
+.form-group input[type="text"],
 .form-group select {
     width: 100%;
     padding: 12px;
@@ -127,6 +128,7 @@ body {
 }
 
 .form-group input[type="number"]:focus,
+.form-group input[type="text"]:focus,
 .form-group select:focus {
     outline: none;
     border-color: #667eea;
@@ -400,15 +402,80 @@ body {
     border-left: 4px solid #388e3c;
 }
 
-.connection-status {
+.connection-widget {
     position: fixed;
     top: 20px;
     right: 20px;
+    z-index: 1000;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.connection-status {
     padding: 10px 20px;
     border-radius: 20px;
     font-size: 0.9em;
     font-weight: 600;
     box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+}
+
+.backend-toggle {
+    width: 36px;
+    height: 36px;
+    border: none;
+    border-radius: 18px;
+    background: white;
+    color: #555;
+    font-size: 16px;
+    cursor: pointer;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.15);
+}
+
+.backend-toggle:hover {
+    background: #f3f4f6;
+}
+
+.backend-popover {
+    display: none;
+    position: absolute;
+    top: 46px;
+    right: 0;
+    width: 280px;
+    padding: 14px;
+    background: white;
+    border-radius: 8px;
+    box-shadow: 0 8px 28px rgba(0, 0, 0, 0.18);
+    border: 1px solid #e5e7eb;
+}
+
+.backend-popover.open {
+    display: block;
+}
+
+.backend-field {
+    margin-bottom: 12px;
+}
+
+.backend-field:last-child {
+    margin-bottom: 0;
+}
+
+.backend-field label {
+    display: block;
+    margin-bottom: 6px;
+    font-size: 13px;
+    font-weight: 600;
+    color: #555;
+}
+
+.backend-field select,
+.backend-field input {
+    width: 100%;
+    padding: 9px 10px;
+    border: 1px solid #d6d6d6;
+    border-radius: 6px;
+    font-size: 14px;
 }
 
 .connection-status.connected {

--- a/style.css
+++ b/style.css
@@ -407,90 +407,200 @@ body {
     top: 20px;
     right: 20px;
     z-index: 1000;
+}
+
+.connection-pill {
     display: flex;
-    align-items: center;
-    gap: 8px;
+    align-items: stretch;
+    min-height: 56px;
+    border-radius: 999px;
+    overflow: hidden;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
+    border: 1px solid rgba(255, 255, 255, 0.38);
+    transition: background 0.25s ease, box-shadow 0.25s ease, transform 0.2s ease;
+}
+
+.connection-pill.connected {
+    background: linear-gradient(135deg, #48bd55 0%, #3cad48 100%);
+}
+
+.connection-pill.disconnected {
+    background: linear-gradient(135deg, #f35b4f 0%, #d93f34 100%);
+}
+
+.connection-pill.connecting {
+    background: linear-gradient(135deg, #ffb13b 0%, #f09116 100%);
 }
 
 .connection-status {
-    padding: 10px 20px;
-    border-radius: 20px;
-    font-size: 0.9em;
-    font-weight: 600;
-    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+    display: flex;
+    align-items: center;
+    padding: 0 14px 0 24px;
+    color: white;
+    font-size: 1.05em;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+    white-space: nowrap;
+    user-select: none;
 }
 
 .backend-toggle {
-    width: 36px;
-    height: 36px;
+    width: 46px;
     border: none;
-    border-radius: 18px;
-    background: white;
-    color: #555;
-    font-size: 16px;
+    border-left: 1px solid rgba(255, 255, 255, 0.35);
+    border-radius: 0;
+    background: rgba(255, 255, 255, 0.14);
+    color: white;
     cursor: pointer;
-    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.15);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: background 0.2s ease;
+}
+
+.backend-toggle::before {
+    content: '▶';
+    width: 24px;
+    height: 24px;
+    border: 1px solid rgba(255, 255, 255, 0.72);
+    border-radius: 7px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.78em;
+    line-height: 1;
+    transform-origin: center;
+    transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.connection-widget.open .backend-toggle::before {
+    transform: rotate(90deg);
+    background: rgba(255, 255, 255, 0.18);
 }
 
 .backend-toggle:hover {
-    background: #f3f4f6;
+    background: rgba(255, 255, 255, 0.22);
 }
 
 .backend-popover {
     display: none;
     position: absolute;
-    top: 46px;
+    top: 66px;
     right: 0;
-    width: 280px;
+    width: 360px;
     padding: 14px;
-    background: white;
-    border-radius: 8px;
-    box-shadow: 0 8px 28px rgba(0, 0, 0, 0.18);
-    border: 1px solid #e5e7eb;
+    background: rgba(255, 255, 255, 0.92);
+    border-radius: 20px;
+    box-shadow: 0 16px 40px rgba(0, 0, 0, 0.22);
+    border: 1px solid rgba(255, 255, 255, 0.7);
+    backdrop-filter: blur(10px);
 }
 
 .backend-popover.open {
-    display: block;
+    display: grid;
+    gap: 10px;
+    animation: backendPopoverIn 0.18s ease;
 }
 
-.backend-field {
-    margin-bottom: 12px;
+@keyframes backendPopoverIn {
+    from {
+        opacity: 0;
+        transform: translateY(-6px);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
 }
 
-.backend-field:last-child {
-    margin-bottom: 0;
+.backend-option {
+    display: grid;
+    grid-template-columns: 82px 1fr;
+    align-items: center;
+    gap: 8px;
+    padding: 9px;
+    border-radius: 15px;
+    border: 1px solid rgba(102, 126, 234, 0.20);
+    background: linear-gradient(135deg, rgba(102, 126, 234, 0.12) 0%, rgba(118, 75, 162, 0.08) 100%);
+    cursor: pointer;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease, background 0.2s ease;
 }
 
-.backend-field label {
-    display: block;
-    margin-bottom: 6px;
-    font-size: 13px;
-    font-weight: 600;
-    color: #555;
+.backend-option:hover {
+    transform: translateY(-1px);
+    border-color: rgba(102, 126, 234, 0.46);
+    box-shadow: 0 8px 18px rgba(102, 126, 234, 0.16);
 }
 
-.backend-field select,
-.backend-field input {
-    width: 100%;
-    padding: 9px 10px;
-    border: 1px solid #d6d6d6;
-    border-radius: 6px;
+.backend-option.active {
+    border-color: rgba(76, 175, 80, 0.72);
+    background: linear-gradient(135deg, rgba(76, 175, 80, 0.16) 0%, rgba(102, 126, 234, 0.10) 100%);
+    box-shadow: 0 8px 20px rgba(76, 175, 80, 0.16);
+}
+
+.backend-option-label {
+    border: none;
+    background: transparent;
+    color: #4f5b6f;
+    font-weight: 800;
     font-size: 14px;
+    text-align: right;
+    cursor: pointer;
+    white-space: nowrap;
 }
 
-.connection-status.connected {
-    background: #4caf50;
-    color: white;
+.backend-option.active .backend-option-label {
+    color: #2f8f3a;
 }
 
-.connection-status.disconnected {
-    background: #f44336;
-    color: white;
+.backend-origin-input {
+    width: 100%;
+    min-width: 0;
+    padding: 10px 12px;
+    border: 1px solid rgba(102, 126, 234, 0.30);
+    border-radius: 11px;
+    background: rgba(255, 255, 255, 0.68);
+    color: #1f2937;
+    font-size: 14px;
+    font-weight: 500;
+    outline: none;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
 }
 
-.connection-status.connecting {
-    background: #ff9800;
-    color: white;
+.backend-origin-input:focus {
+    border-color: #667eea;
+    background: rgba(255, 255, 255, 0.96);
+    box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.16);
+}
+
+@media (max-width: 520px) {
+    .connection-widget {
+        top: 12px;
+        right: 12px;
+    }
+
+    .connection-pill {
+        min-height: 46px;
+    }
+
+    .connection-status {
+        padding-left: 16px;
+        font-size: 0.92em;
+    }
+
+    .backend-toggle {
+        width: 40px;
+    }
+
+    .backend-popover {
+        width: min(340px, calc(100vw - 24px));
+        top: 56px;
+    }
+
+    .backend-option {
+        grid-template-columns: 70px 1fr;
+    }
 }
 
 .bilibili-link,


### PR DESCRIPTION
## Summary

引入go后端作为**API网关**和**任务分发器**，让C#只进行种子的逻辑计算；利用go的高并发来提升种子计算效率

> [!note]
> 目前在`intel i7-13620H`上的测试显示：在复杂种子筛选逻辑和简单种子筛选逻辑下，筛种速度都能快4-5倍

## Verify

#### 复杂条件下的测试：
https://github.com/user-attachments/assets/663dd9ab-e448-4125-85b4-6cdb09b27aa7

#### 简单条件下的测试：
https://github.com/user-attachments/assets/f8250445-1e75-445e-8bd6-b25fe0c75553


## Potential issues

> [!warning]
> emmm，因为筛的太快了，前端目前有那么一点点点点卡，我是目前没有找到很好的解决方案，我觉得如果这版本可以合并的话，后续可以开个issue，或者看我近期能不能解决这个问题吧(前端的选择后端部分我觉得有点简陋了，整体不协调，后续会再commit去美化一下)
